### PR TITLE
Support for environment variables in script execution

### DIFF
--- a/provisioner/windows-shell/provisioner.go
+++ b/provisioner/windows-shell/provisioner.go
@@ -51,6 +51,10 @@ type config struct {
 	// This can be set high to allow for reboots.
 	RawStartRetryTimeout string `mapstructure:"start_retry_timeout"`
 
+	// This is used in the template generation to format environment variables
+	// inside the `ExecuteCommand` template.
+	EnvVarFormat string
+
 	startRetryTimeout time.Duration
 	tpl               *packer.ConfigTemplate
 }
@@ -79,8 +83,12 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	// Accumulate any errors
 	errs := common.CheckUnusedConfig(md)
 
+	if p.config.EnvVarFormat == "" {
+		p.config.EnvVarFormat = `$env:%s=\"%s\"; `
+	}
+
 	if p.config.ExecuteCommand == "" {
-		p.config.ExecuteCommand = "{{.Vars}} powershell -Command {{.Path}}"
+		p.config.ExecuteCommand = `powershell "& { {{.Vars}}{{.Path}} }"`
 	}
 
 	if p.config.Inline != nil && len(p.config.Inline) == 0 {
@@ -321,18 +329,15 @@ func (p *Provisioner) createFlattenedEnvVars() (flattened string, err error) {
 		}
 		envVars[keyValue[0]] = keyValue[1]
 	}
-
 	// Create a list of env var keys in sorted order
 	var keys []string
 	for k := range envVars {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-
 	// Re-assemble vars using OS specific format pattern and flatten
 	for _, key := range keys {
-		flattened += fmt.Sprintf("powershell -Command \"$env:%s='%s'\"; ", key, envVars[key])
+		flattened += fmt.Sprintf(p.config.EnvVarFormat, key, envVars[key])
 	}
-
 	return
 }

--- a/provisioner/windows-shell/provisioner_test.go
+++ b/provisioner/windows-shell/provisioner_test.go
@@ -35,8 +35,8 @@ func TestProvisionerPrepare_Defaults(t *testing.T) {
 		t.Errorf("unexpected remote path: %s", p.config.RemotePath)
 	}
 
-	if p.config.ExecuteCommand != "{{.Vars}} powershell -Command {{.Path}}" {
-		t.Fatalf("Default command should be '{{.Vars}} powershell -Command {{.Path}}'")
+	if p.config.ExecuteCommand != "powershell \"& { {{.Vars}}{{.Path}} }\"" {
+		t.Fatalf("Default command should be powershell \"& { {{.Vars}}{{.Path}} }\", but got %s", p.config.ExecuteCommand)
 	}
 }
 
@@ -275,7 +275,7 @@ func TestProvisioner_createFlattenedEnvVars_windows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not have error creating flattened env vars: %s", err)
 	}
-	if flattenedEnvVars != "powershell -Command \"$env:PACKER_BUILDER_TYPE='iso'\"; powershell -Command \"$env:PACKER_BUILD_NAME='vmware'\"; " {
+	if flattenedEnvVars != "$env:PACKER_BUILDER_TYPE=\\\"iso\\\"; $env:PACKER_BUILD_NAME=\\\"vmware\\\"; " {
 		t.Fatalf("unexpected flattened env vars: %s", flattenedEnvVars)
 	}
 
@@ -286,7 +286,7 @@ func TestProvisioner_createFlattenedEnvVars_windows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not have error creating flattened env vars: %s", err)
 	}
-	if flattenedEnvVars != "powershell -Command \"$env:FOO='bar'\"; powershell -Command \"$env:PACKER_BUILDER_TYPE='iso'\"; powershell -Command \"$env:PACKER_BUILD_NAME='vmware'\"; " {
+	if flattenedEnvVars != "$env:FOO=\\\"bar\\\"; $env:PACKER_BUILDER_TYPE=\\\"iso\\\"; $env:PACKER_BUILD_NAME=\\\"vmware\\\"; " {
 		t.Fatalf("unexpected flattened env vars: %s", flattenedEnvVars)
 	}
 
@@ -297,7 +297,7 @@ func TestProvisioner_createFlattenedEnvVars_windows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not have error creating flattened env vars: %s", err)
 	}
-	if flattenedEnvVars != "powershell -Command \"$env:BAZ='qux'\"; powershell -Command \"$env:FOO='bar'\"; powershell -Command \"$env:PACKER_BUILDER_TYPE='iso'\"; powershell -Command \"$env:PACKER_BUILD_NAME='vmware'\"; " {
+	if flattenedEnvVars != "$env:BAZ=\\\"qux\\\"; $env:FOO=\\\"bar\\\"; $env:PACKER_BUILDER_TYPE=\\\"iso\\\"; $env:PACKER_BUILD_NAME=\\\"vmware\\\"; " {
 		t.Fatalf("unexpected flattened env vars: %s", flattenedEnvVars)
 	}
 }

--- a/provisioner/windows-shell/provisioner_test.go
+++ b/provisioner/windows-shell/provisioner_test.go
@@ -2,10 +2,14 @@ package shell
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"github.com/mitchellh/packer/packer"
 	"io/ioutil"
+	"log"
 	"os"
 	"testing"
+	"time"
 )
 
 func testConfig() map[string]interface{} {
@@ -227,28 +231,98 @@ func TestProvisionerProvision_Inline(t *testing.T) {
 	config := testConfig()
 	delete(config, "inline")
 	config["scripts"] = []string{}
+	config["inline"] = "powershell -command Foo-Command"
 	ui := testUi()
 
 	p := new(Provisioner)
 	comm := new(packer.MockCommunicator)
 	p.Prepare(config)
 	err := p.Provision(ui, comm)
-
-	// Should create a remote command from
-
 	if err != nil {
 		t.Fatal("should not have error")
 	}
 
+	// Should run the command without alteration
+	if comm.StartCmd.Command != config["inline"] {
+		t.Fatalf("Expect command not to be: %s", comm.StartCmd.Command)
+	}
+
+	// Env vars - currently should not effect them
+	envVars := make([]string, 2)
+	envVars[0] = "FOO=BAR"
+	envVars[1] = "BAR=BAZ"
+	config["Vars"] = envVars
+
+	p.Prepare(config)
+	err = p.Provision(ui, comm)
+	if err != nil {
+		t.Fatal("should not have error")
+	}
+
+	// Should run the command without alteration
+	if comm.StartCmd.Command != config["inline"] {
+		t.Fatalf("Expect command not to be: %s", comm.StartCmd.Command)
+	}
 }
 
 func TestProvisionerProvision_Scripts(t *testing.T) {
+	tempFile, _ := ioutil.TempFile("", "packer")
+	defer os.Remove(tempFile.Name())
+	config := testConfig()
+	delete(config, "inline")
+	config["scripts"] = []string{tempFile.Name()}
+	config["packer_build_name"] = "foobuild"
+	config["packer_builder_type"] = "footype"
+	ui := testUi()
 
-	// Create n scripts
+	p := new(Provisioner)
+	comm := new(packer.MockCommunicator)
+	p.Prepare(config)
+	err := p.Provision(ui, comm)
+	if err != nil {
+		t.Fatal("should not have error")
+	}
 
-	// Should execute them in order from 1-n
+	//powershell -Command "$env:PACKER_BUILDER_TYPE=''"; powershell -Command "$env:PACKER_BUILD_NAME='foobuild'";  powershell -Command c:/Windows/Temp/script.ps1
+	expectedCommand := `powershell "& { $env:PACKER_BUILDER_TYPE=\"footype\"; $env:PACKER_BUILD_NAME=\"foobuild\"; c:/Windows/Temp/script.ps1 }"`
 
-	// Should invoke 'runcommand' / 'Start'
+	// Should run the command without alteration
+	if comm.StartCmd.Command != expectedCommand {
+		t.Fatalf("Expect command to be %s NOT %s", expectedCommand, comm.StartCmd.Command)
+	}
+}
+
+func TestProvisionerProvision_ScriptsWithEnvVars(t *testing.T) {
+	tempFile, _ := ioutil.TempFile("", "packer")
+	config := testConfig()
+	ui := testUi()
+	defer os.Remove(tempFile.Name())
+	delete(config, "inline")
+
+	config["scripts"] = []string{tempFile.Name()}
+	config["packer_build_name"] = "foobuild"
+	config["packer_builder_type"] = "footype"
+
+	// Env vars - currently should not effect them
+	envVars := make([]string, 2)
+	envVars[0] = "FOO=BAR"
+	envVars[1] = "BAR=BAZ"
+	config["environment_vars"] = envVars
+
+	p := new(Provisioner)
+	comm := new(packer.MockCommunicator)
+	p.Prepare(config)
+	err := p.Provision(ui, comm)
+	if err != nil {
+		t.Fatal("should not have error")
+	}
+
+	expectedCommand := `powershell "& { $env:BAR=\"BAZ\"; $env:FOO=\"BAR\"; $env:PACKER_BUILDER_TYPE=\"footype\"; $env:PACKER_BUILD_NAME=\"foobuild\"; c:/Windows/Temp/script.ps1 }"`
+
+	// Should run the command without alteration
+	if comm.StartCmd.Command != expectedCommand {
+		t.Fatalf("Expect command to be %s NOT %s", expectedCommand, comm.StartCmd.Command)
+	}
 }
 
 func TestProvisionerProvision_UISlurp(t *testing.T) {
@@ -300,4 +374,39 @@ func TestProvisioner_createFlattenedEnvVars_windows(t *testing.T) {
 	if flattenedEnvVars != "$env:BAZ=\\\"qux\\\"; $env:FOO=\\\"bar\\\"; $env:PACKER_BUILDER_TYPE=\\\"iso\\\"; $env:PACKER_BUILD_NAME=\\\"vmware\\\"; " {
 		t.Fatalf("unexpected flattened env vars: %s", flattenedEnvVars)
 	}
+}
+
+func TestRetryable(t *testing.T) {
+	config := testConfig()
+
+	count := 0
+	retryMe := func() error {
+		log.Printf("RetryMe, attempt number %d", count)
+		if count == 2 {
+			return nil
+		}
+		count++
+		return errors.New(fmt.Sprintf("Still waiting %d more times...", 2-count))
+	}
+	retryableSleep = 50 * time.Millisecond
+	p := new(Provisioner)
+	p.config.RawStartRetryTimeout = "155ms"
+	err := p.Prepare(config)
+	err = p.retryable(retryMe)
+	if err != nil {
+		t.Fatalf("should not have error retrying funuction")
+	}
+
+	count = 0
+	p.config.RawStartRetryTimeout = "10ms"
+	err = p.Prepare(config)
+	err = p.retryable(retryMe)
+	if err == nil {
+		t.Fatalf("should have error retrying funuction")
+	}
+}
+
+func TestCancel(t *testing.T) {
+	p := new(Provisioner)
+	p.Cancel()
 }


### PR DESCRIPTION
This PR addresses issue #6, supporting environment variables in the ExecuteCommand template for Powershell scripts only. That is, inline scripts of any sort or cmd scripts will not support the {{.Vars}} template variable.