### PR TITLE
Concatenating inline scripts into a temporary file fails on Windows hosts

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -199,7 +199,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 // into a temporary file and returns a string containing the location
 // of said file.
 func extractScript(p *Provisioner) (string, error) {
-	temp, err := ioutil.TempFile("/tmp", "packer-powershell-provisioner")
+	temp, err := ioutil.TempFile(os.TempDir(), "packer-powershell-provisioner")
 	if err != nil {
 		log.Printf("Unable to create temporary file for inline scripts: %s", err)
 		return "", err

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -27,8 +27,8 @@ func TestProvisionerPrepare_extractScript(t *testing.T) {
 		t.Fatalf("Should not be error: %s", err)
 	}
 	t.Logf("File: %s", file)
-	if strings.Index(file, "/tmp") != 0 {
-		t.Fatalf("Temp file should reside in /tmp. File location: %s", file)
+	if strings.Index(file, os.TempDir()) != 0 {
+		t.Fatalf("Temp file should reside in %s. File location: %s", os.TempDir(), file)
 	}
 
 	// File contents should contain 2 lines concatenated by newlines: foo\nbar

--- a/provisioner/windows-shell/provisioner.go
+++ b/provisioner/windows-shell/provisioner.go
@@ -199,7 +199,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 // into a temporary file and returns a string containing the location
 // of said file.
 func extractScript(p *Provisioner) (string, error) {
-	temp, err := ioutil.TempFile("/tmp", "packer-windows-shell-provisioner")
+	temp, err := ioutil.TempFile(os.TempDir(), "packer-windows-shell-provisioner")
 	if err != nil {
 		log.Printf("Unable to create temporary file for inline scripts: %s", err)
 		return "", err

--- a/provisioner/windows-shell/provisioner_test.go
+++ b/provisioner/windows-shell/provisioner_test.go
@@ -28,8 +28,8 @@ func TestProvisionerPrepare_extractScript(t *testing.T) {
 		t.Fatalf("Should not be error: %s", err)
 	}
 	log.Printf("File: %s", file)
-	if strings.Index(file, "/tmp") != 0 {
-		t.Fatalf("Temp file should reside in /tmp. File location: %s", file)
+	if strings.Index(file, os.TempDir()) != 0 {
+		t.Fatalf("Temp file should reside in %s. File location: %s", os.TempDir(), file)
 	}
 
 	// File contents should contain 2 lines concatenated by newlines: foo\nbar


### PR DESCRIPTION
With the current code, the following error occurs when executing Packer on Windows with the powershell provisioner and the windows shell provisioner:

```
==> virtualbox-windows-iso: Unable to extract inline scripts into a file: open \tmp\packer-powershell-provisioner199224447: The system cannot find the path specified.
```

Windows interprets this path as `C:\tmp\packer-powershell-provisioner199224447` assuming your current working directory was on C: drive when you executed packer (D:\tmp\ ... if you're currently on D: drive). In normal circumstances `C:\tmp\` directory doesn't exist - but creating the directory is a quick hack to solve the error above.

The changes in this PR make use of the `os.TempDir` method which is a platform independent way of getting the default temporary directory. On *NIX the temporary directory will continue to be `/tmp/` but on Windows it will change to something like below:

```
==> virtualbox-windows-iso: Provisioning with shell script: C:\Users\Ben\AppData\Local\Temp\packer-powershell-provisioner003844411
```