### PR TITLE
Parallels ISO and PVM builders

### DIFF
--- a/builder/parallels-windows/common/connect_step.go
+++ b/builder/parallels-windows/common/connect_step.go
@@ -5,24 +5,34 @@ import (
 	"log"
 
 	"github.com/mitchellh/multistep"
+	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
 	wincommon "github.com/packer-community/packer-windows-plugins/common"
 )
 
 func WinRMAddressFunc(config wincommon.WinRMConfig) func(state multistep.StateBag) (string, error) {
-	if config.WinRMHost == "" {
-		log.Printf("No WinRM Host provided, using default host 127.0.0.1")
-		config.WinRMHost = "127.0.0.1"
-	}
-
-	log.Printf("Have address from config: %s:%d", config.WinRMHost, config.WinRMPort)
 
 	return func(state multistep.StateBag) (string, error) {
+		log.Printf("Determining WinRM remote IP address...")
+		vmName := state.Get("vmName").(string)
+		driver := state.Get("driver").(parallelscommon.Driver)
+
+		mac, err := driver.Mac(vmName)
+		if err != nil {
+			return "", err
+		}
+
+		ip, err := driver.IpAddress(mac)
+		if err != nil {
+			return "", err
+		}
+
 		winrmPort := config.WinRMPort
 		if forwardedPort, ok := state.GetOk("winrmHostPort"); ok {
 			winrmPort = forwardedPort.(uint)
 		}
 
-		return fmt.Sprintf("%s:%d", config.WinRMHost, winrmPort), nil
+		log.Printf("Detected WinRM address to be: %s:%d", ip, winrmPort)
+		return fmt.Sprintf("%s:%d", ip, winrmPort), nil
 	}
 }
 

--- a/builder/parallels-windows/common/connect_step.go
+++ b/builder/parallels-windows/common/connect_step.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/mitchellh/multistep"
+	wincommon "github.com/packer-community/packer-windows-plugins/common"
+)
+
+func WinRMAddressFunc(config wincommon.WinRMConfig) func(state multistep.StateBag) (string, error) {
+	if config.WinRMHost == "" {
+		log.Printf("No WinRM Host provided, using default host 127.0.0.1")
+		config.WinRMHost = "127.0.0.1"
+	}
+
+	log.Printf("Have address from config: %s:%d", config.WinRMHost, config.WinRMPort)
+
+	return func(state multistep.StateBag) (string, error) {
+		winrmPort := config.WinRMPort
+		if forwardedPort, ok := state.GetOk("winrmHostPort"); ok {
+			winrmPort = forwardedPort.(uint)
+		}
+
+		return fmt.Sprintf("%s:%d", config.WinRMHost, winrmPort), nil
+	}
+}
+
+// Creates a generic WinRM connect step from a Parallels builder config
+func NewConnectStep(winrmConfig wincommon.WinRMConfig) multistep.Step {
+	return &wincommon.StepConnectWinRM{
+		WinRMAddress:     WinRMAddressFunc(winrmConfig),
+		WinRMUser:        winrmConfig.WinRMUser,
+		WinRMPassword:    winrmConfig.WinRMPassword,
+		WinRMWaitTimeout: winrmConfig.WinRMWaitTimeout,
+	}
+}

--- a/builder/parallels-windows/common/connect_step_test.go
+++ b/builder/parallels-windows/common/connect_step_test.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/mitchellh/multistep"
+	wincommon "github.com/packer-community/packer-windows-plugins/common"
+)
+
+func TestWinRMAddressFunc_UsesPortForwarding(t *testing.T) {
+	config := wincommon.WinRMConfig{
+		WinRMHost: "localhost",
+		WinRMPort: 456,
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("winrmHostPort", uint(123))
+
+	f := WinRMAddressFunc(config)
+	address, err := f(state)
+
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+
+	if address != "localhost:123" {
+		t.Errorf("should have forwarded to port 123, but was %s", address)
+	}
+}

--- a/builder/parallels-windows/common/connect_step_test.go
+++ b/builder/parallels-windows/common/connect_step_test.go
@@ -1,11 +1,32 @@
 package common
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/mitchellh/multistep"
+	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
 	wincommon "github.com/packer-community/packer-windows-plugins/common"
 )
+
+func TestWinRMAddressFunc_UsesPortForwardingFail(t *testing.T) {
+	config := wincommon.WinRMConfig{
+		WinRMHost: "localhost",
+		WinRMPort: 456,
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("winrmHostPort", uint(123))
+	state.Put("driver", &parallelscommon.DriverMock{IpAddressError: errors.New("Invalid machine state"), MacReturn: "01cd123"})
+	state.Put("vmName", "myvmname")
+
+	f := WinRMAddressFunc(config)
+	_, err := f(state)
+
+	if err == nil {
+		t.Fatalf("Expected err %v", err)
+	}
+}
 
 func TestWinRMAddressFunc_UsesPortForwarding(t *testing.T) {
 	config := wincommon.WinRMConfig{
@@ -15,6 +36,8 @@ func TestWinRMAddressFunc_UsesPortForwarding(t *testing.T) {
 
 	state := new(multistep.BasicStateBag)
 	state.Put("winrmHostPort", uint(123))
+	state.Put("driver", &parallelscommon.DriverMock{IpAddressReturn: "172.17.4.13", MacReturn: "01cd123"})
+	state.Put("vmName", "myvmname")
 
 	f := WinRMAddressFunc(config)
 	address, err := f(state)
@@ -23,7 +46,7 @@ func TestWinRMAddressFunc_UsesPortForwarding(t *testing.T) {
 		t.Fatalf("unexpected err %v", err)
 	}
 
-	if address != "localhost:123" {
+	if address != "172.17.4.13:123" {
 		t.Errorf("should have forwarded to port 123, but was %s", address)
 	}
 }

--- a/builder/parallels-windows/iso/builder.go
+++ b/builder/parallels-windows/iso/builder.go
@@ -1,0 +1,340 @@
+package iso
+
+import (
+	"errors"
+	"fmt"
+	"github.com/mitchellh/multistep"
+	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
+	"github.com/mitchellh/packer/common"
+	"github.com/mitchellh/packer/packer"
+	winparallelscommon "github.com/packer-community/packer-windows-plugins/builder/parallels-windows/common"
+	wincommon "github.com/packer-community/packer-windows-plugins/common"
+	"log"
+	"strings"
+)
+
+const BuilderId = "rickard-von-essen.parallels"
+
+type Builder struct {
+	config config
+	runner multistep.Runner
+}
+
+type config struct {
+	common.PackerConfig                 `mapstructure:",squash"`
+	parallelscommon.FloppyConfig        `mapstructure:",squash"`
+	parallelscommon.OutputConfig        `mapstructure:",squash"`
+	parallelscommon.PrlctlConfig        `mapstructure:",squash"`
+	parallelscommon.PrlctlVersionConfig `mapstructure:",squash"`
+	parallelscommon.RunConfig           `mapstructure:",squash"`
+	parallelscommon.ShutdownConfig      `mapstructure:",squash"`
+	wincommon.WinRMConfig               `mapstructure:",squash"`
+	parallelscommon.ToolsConfig         `mapstructure:",squash"`
+
+	BootCommand        []string `mapstructure:"boot_command"`
+	DiskSize           uint     `mapstructure:"disk_size"`
+	GuestOSType        string   `mapstructure:"guest_os_type"`
+	HardDriveInterface string   `mapstructure:"hard_drive_interface"`
+	HostInterfaces     []string `mapstructure:"host_interfaces"`
+	HTTPDir            string   `mapstructure:"http_directory"`
+	HTTPPortMin        uint     `mapstructure:"http_port_min"`
+	HTTPPortMax        uint     `mapstructure:"http_port_max"`
+	ISOChecksum        string   `mapstructure:"iso_checksum"`
+	ISOChecksumType    string   `mapstructure:"iso_checksum_type"`
+	ISOUrls            []string `mapstructure:"iso_urls"`
+	VMName             string   `mapstructure:"vm_name"`
+
+	RawSingleISOUrl string `mapstructure:"iso_url"`
+
+	// Deprecated parameters
+	GuestOSDistribution    string `mapstructure:"guest_os_distribution"`
+	ParallelsToolsHostPath string `mapstructure:"parallels_tools_host_path"`
+
+	tpl *packer.ConfigTemplate
+}
+
+func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
+
+	md, err := common.DecodeConfig(&b.config, raws...)
+	if err != nil {
+		return nil, err
+	}
+
+	b.config.tpl, err = packer.NewConfigTemplate()
+	if err != nil {
+		return nil, err
+	}
+	b.config.tpl.UserVars = b.config.PackerUserVars
+
+	// Accumulate any errors and warnings
+	errs := common.CheckUnusedConfig(md)
+	errs = packer.MultiErrorAppend(errs, b.config.FloppyConfig.Prepare(b.config.tpl)...)
+	errs = packer.MultiErrorAppend(
+		errs, b.config.OutputConfig.Prepare(b.config.tpl, &b.config.PackerConfig)...)
+	errs = packer.MultiErrorAppend(errs, b.config.RunConfig.Prepare(b.config.tpl)...)
+	errs = packer.MultiErrorAppend(errs, b.config.PrlctlConfig.Prepare(b.config.tpl)...)
+	errs = packer.MultiErrorAppend(errs, b.config.PrlctlVersionConfig.Prepare(b.config.tpl)...)
+	errs = packer.MultiErrorAppend(errs, b.config.ShutdownConfig.Prepare(b.config.tpl)...)
+	errs = packer.MultiErrorAppend(errs, b.config.WinRMConfig.Prepare(b.config.tpl)...)
+	errs = packer.MultiErrorAppend(errs, b.config.ToolsConfig.Prepare(b.config.tpl)...)
+	warnings := make([]string, 0)
+
+	if b.config.DiskSize == 0 {
+		b.config.DiskSize = 40000
+	}
+
+	if b.config.HardDriveInterface == "" {
+		b.config.HardDriveInterface = "sata"
+	}
+
+	if b.config.GuestOSType == "" {
+		b.config.GuestOSType = "other"
+	}
+
+	if b.config.GuestOSDistribution != "" {
+		// Compatibility with older templates:
+		// Use value of 'guest_os_distribution' if it is defined.
+		b.config.GuestOSType = b.config.GuestOSDistribution
+		warnings = append(warnings,
+			"A 'guest_os_distribution' has been completely replaced with 'guest_os_type'\n"+
+				"It is recommended to remove it and assign the previous value to 'guest_os_type'.\n"+
+				"Run it to see all available values: `prlctl create x -d list` ")
+	}
+
+	if b.config.HTTPPortMin == 0 {
+		b.config.HTTPPortMin = 8000
+	}
+
+	if b.config.HTTPPortMax == 0 {
+		b.config.HTTPPortMax = 9000
+	}
+
+	if len(b.config.HostInterfaces) == 0 {
+		b.config.HostInterfaces = []string{"en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7",
+			"en8", "en9", "ppp0", "ppp1", "ppp2"}
+	}
+
+	if b.config.VMName == "" {
+		b.config.VMName = fmt.Sprintf("packer-%s", b.config.PackerBuildName)
+	}
+
+	// Errors
+	templates := map[string]*string{
+		"guest_os_type":        &b.config.GuestOSType,
+		"hard_drive_interface": &b.config.HardDriveInterface,
+		"http_directory":       &b.config.HTTPDir,
+		"iso_checksum":         &b.config.ISOChecksum,
+		"iso_checksum_type":    &b.config.ISOChecksumType,
+		"iso_url":              &b.config.RawSingleISOUrl,
+		"vm_name":              &b.config.VMName,
+	}
+
+	for n, ptr := range templates {
+		var err error
+		*ptr, err = b.config.tpl.Process(*ptr, nil)
+		if err != nil {
+			errs = packer.MultiErrorAppend(
+				errs, fmt.Errorf("Error processing %s: %s", n, err))
+		}
+	}
+
+	for i, url := range b.config.ISOUrls {
+		var err error
+		b.config.ISOUrls[i], err = b.config.tpl.Process(url, nil)
+		if err != nil {
+			errs = packer.MultiErrorAppend(
+				errs, fmt.Errorf("Error processing iso_urls[%d]: %s", i, err))
+		}
+	}
+
+	for i, command := range b.config.BootCommand {
+		if err := b.config.tpl.Validate(command); err != nil {
+			errs = packer.MultiErrorAppend(errs,
+				fmt.Errorf("Error processing boot_command[%d]: %s", i, err))
+		}
+	}
+
+	if b.config.HardDriveInterface != "ide" && b.config.HardDriveInterface != "sata" && b.config.HardDriveInterface != "scsi" {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("hard_drive_interface can only be ide, sata, or scsi"))
+	}
+
+	if b.config.HTTPPortMin > b.config.HTTPPortMax {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("http_port_min must be less than http_port_max"))
+	}
+
+	if b.config.ISOChecksumType == "" {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("The iso_checksum_type must be specified."))
+	} else {
+		b.config.ISOChecksumType = strings.ToLower(b.config.ISOChecksumType)
+		if b.config.ISOChecksumType != "none" {
+			if b.config.ISOChecksum == "" {
+				errs = packer.MultiErrorAppend(
+					errs, errors.New("Due to large file sizes, an iso_checksum is required"))
+			} else {
+				b.config.ISOChecksum = strings.ToLower(b.config.ISOChecksum)
+			}
+
+			if h := common.HashForType(b.config.ISOChecksumType); h == nil {
+				errs = packer.MultiErrorAppend(
+					errs,
+					fmt.Errorf("Unsupported checksum type: %s", b.config.ISOChecksumType))
+			}
+		}
+	}
+
+	if b.config.RawSingleISOUrl == "" && len(b.config.ISOUrls) == 0 {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("One of iso_url or iso_urls must be specified."))
+	} else if b.config.RawSingleISOUrl != "" && len(b.config.ISOUrls) > 0 {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("Only one of iso_url or iso_urls may be specified."))
+	} else if b.config.RawSingleISOUrl != "" {
+		b.config.ISOUrls = []string{b.config.RawSingleISOUrl}
+	}
+
+	for i, url := range b.config.ISOUrls {
+		b.config.ISOUrls[i], err = common.DownloadableURL(url)
+		if err != nil {
+			errs = packer.MultiErrorAppend(
+				errs, fmt.Errorf("Failed to parse iso_url %d: %s", i+1, err))
+		}
+	}
+
+	// Warnings
+	if b.config.ISOChecksumType == "none" {
+		warnings = append(warnings,
+			"A checksum type of 'none' was specified. Since ISO files are so big,\n"+
+				"a checksum is highly recommended.")
+	}
+
+	if b.config.ShutdownCommand == "" {
+		warnings = append(warnings,
+			"A shutdown_command was not specified. Without a shutdown command, Packer\n"+
+				"will forcibly halt the virtual machine, which may result in data loss.")
+	}
+
+	if b.config.ParallelsToolsHostPath != "" {
+		warnings = append(warnings,
+			"A 'parallels_tools_host_path' has been deprecated and not in use anymore\n"+
+				"You can remove it from your Packer template.")
+	}
+
+	if errs != nil && len(errs.Errors) > 0 {
+		return warnings, errs
+	}
+
+	return warnings, nil
+}
+
+func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packer.Artifact, error) {
+	// Create the driver that we'll use to communicate with Parallels
+	driver, err := parallelscommon.NewDriver()
+	if err != nil {
+		return nil, fmt.Errorf("Failed creating Parallels driver: %s", err)
+	}
+
+	steps := []multistep.Step{
+		&parallelscommon.StepPrepareParallelsTools{
+			ParallelsToolsFlavor: b.config.ParallelsToolsFlavor,
+			ParallelsToolsMode:   b.config.ParallelsToolsMode,
+		},
+		&common.StepDownload{
+			Checksum:     b.config.ISOChecksum,
+			ChecksumType: b.config.ISOChecksumType,
+			Description:  "ISO",
+			ResultKey:    "iso_path",
+			Url:          b.config.ISOUrls,
+		},
+		&parallelscommon.StepOutputDir{
+			Force: b.config.PackerForce,
+			Path:  b.config.OutputDir,
+		},
+		&common.StepCreateFloppy{
+			Files: b.config.FloppyFiles,
+		},
+		new(stepHTTPServer),
+		new(stepCreateVM),
+		new(stepCreateDisk),
+		new(stepSetBootOrder),
+		new(stepAttachISO),
+		&parallelscommon.StepAttachParallelsTools{
+			ParallelsToolsMode: b.config.ParallelsToolsMode,
+		},
+		new(parallelscommon.StepAttachFloppy),
+		&parallelscommon.StepPrlctl{
+			Commands: b.config.Prlctl,
+			Tpl:      b.config.tpl,
+		},
+		&parallelscommon.StepRun{
+			BootWait: b.config.BootWait,
+			Headless: b.config.Headless, // TODO: migth work on Enterprise Ed.
+		},
+		&parallelscommon.StepTypeBootCommand{
+			BootCommand:    b.config.BootCommand,
+			HostInterfaces: b.config.HostInterfaces,
+			VMName:         b.config.VMName,
+			Tpl:            b.config.tpl,
+		},
+		winparallelscommon.NewConnectStep(b.config.WinRMConfig),
+		&parallelscommon.StepUploadVersion{
+			Path: b.config.PrlctlVersionFile,
+		},
+		&parallelscommon.StepUploadParallelsTools{
+			ParallelsToolsFlavor:    b.config.ParallelsToolsFlavor,
+			ParallelsToolsGuestPath: b.config.ParallelsToolsGuestPath,
+			ParallelsToolsMode:      b.config.ParallelsToolsMode,
+			Tpl:                     b.config.tpl,
+		},
+		new(common.StepProvision),
+		&parallelscommon.StepShutdown{
+			Command: b.config.ShutdownCommand,
+			Timeout: b.config.ShutdownTimeout,
+		},
+	}
+
+	// Setup the state bag
+	state := new(multistep.BasicStateBag)
+	state.Put("cache", cache)
+	state.Put("config", &b.config)
+	state.Put("driver", driver)
+	state.Put("hook", hook)
+	state.Put("ui", ui)
+
+	// Run
+	if b.config.PackerDebug {
+		b.runner = &multistep.DebugRunner{
+			Steps:   steps,
+			PauseFn: common.MultistepDebugFn(ui),
+		}
+	} else {
+		b.runner = &multistep.BasicRunner{Steps: steps}
+	}
+
+	b.runner.Run(state)
+
+	// If there was an error, return that
+	if rawErr, ok := state.GetOk("error"); ok {
+		return nil, rawErr.(error)
+	}
+
+	// If we were interrupted or cancelled, then just exit.
+	if _, ok := state.GetOk(multistep.StateCancelled); ok {
+		return nil, errors.New("Build was cancelled.")
+	}
+
+	if _, ok := state.GetOk(multistep.StateHalted); ok {
+		return nil, errors.New("Build was halted.")
+	}
+
+	return parallelscommon.NewArtifact(b.config.OutputDir)
+}
+
+func (b *Builder) Cancel() {
+	if b.runner != nil {
+		log.Println("Cancelling the step runner...")
+		b.runner.Cancel()
+	}
+}

--- a/builder/parallels-windows/iso/builder_test.go
+++ b/builder/parallels-windows/iso/builder_test.go
@@ -1,0 +1,367 @@
+package iso
+
+import (
+	"github.com/mitchellh/packer/packer"
+	"reflect"
+	"testing"
+)
+
+func testConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"iso_checksum":           "foo",
+		"iso_checksum_type":      "md5",
+		"iso_url":                "http://www.google.com/",
+		"shutdown_command":       "yes",
+		"winrm_username":         "foo",
+		"winrm_password":         "foo",
+		"parallels_tools_flavor": "lin",
+
+		packer.BuildNameConfigKey: "foo",
+	}
+}
+
+func TestBuilder_ImplementsBuilder(t *testing.T) {
+	var raw interface{}
+	raw = &Builder{}
+	if _, ok := raw.(packer.Builder); !ok {
+		t.Error("Builder must implement builder.")
+	}
+}
+
+func TestBuilderPrepare_Defaults(t *testing.T) {
+	var b Builder
+	config := testConfig()
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if b.config.GuestOSType != "other" {
+		t.Errorf("bad guest OS type: %s", b.config.GuestOSType)
+	}
+
+	if b.config.VMName != "packer-foo" {
+		t.Errorf("bad vm name: %s", b.config.VMName)
+	}
+}
+
+func TestBuilderPrepare_DiskSize(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	delete(config, "disk_size")
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("bad err: %s", err)
+	}
+
+	if b.config.DiskSize != 40000 {
+		t.Fatalf("bad size: %d", b.config.DiskSize)
+	}
+
+	config["disk_size"] = 60000
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if b.config.DiskSize != 60000 {
+		t.Fatalf("bad size: %s", b.config.DiskSize)
+	}
+}
+
+func TestBuilderPrepare_GuestOSType(t *testing.T) {
+	var b Builder
+	config := testConfig()
+	delete(config, "guest_os_distribution")
+
+	// Test deprecated parameter
+	config["guest_os_distribution"] = "bolgenos"
+	warns, err := b.Prepare(config)
+	if len(warns) == 0 {
+		t.Fatalf("should have warning")
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+	if b.config.GuestOSType != "bolgenos" {
+		t.Fatalf("bad: %s", b.config.GuestOSType)
+	}
+}
+
+func TestBuilderPrepare_HardDriveInterface(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Test a default boot_wait
+	delete(config, "hard_drive_interface")
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if b.config.HardDriveInterface != "sata" {
+		t.Fatalf("bad: %s", b.config.HardDriveInterface)
+	}
+
+	// Test with a bad
+	config["hard_drive_interface"] = "fake"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Test with a good
+	config["hard_drive_interface"] = "scsi"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+}
+
+func TestBuilderPrepare_HTTPPort(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Bad
+	config["http_port_min"] = 1000
+	config["http_port_max"] = 500
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Bad
+	config["http_port_min"] = -500
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Good
+	config["http_port_min"] = 500
+	config["http_port_max"] = 1000
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+}
+
+func TestBuilderPrepare_InvalidKey(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Add a random key
+	config["i_should_not_be_valid"] = true
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+}
+
+func TestBuilderPrepare_ISOChecksum(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Test bad
+	config["iso_checksum"] = ""
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Test good
+	config["iso_checksum"] = "FOo"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if b.config.ISOChecksum != "foo" {
+		t.Fatalf("should've lowercased: %s", b.config.ISOChecksum)
+	}
+}
+
+func TestBuilderPrepare_ISOChecksumType(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Test bad
+	config["iso_checksum_type"] = ""
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Test good
+	config["iso_checksum_type"] = "mD5"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if b.config.ISOChecksumType != "md5" {
+		t.Fatalf("should've lowercased: %s", b.config.ISOChecksumType)
+	}
+
+	// Test unknown
+	config["iso_checksum_type"] = "fake"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Test none
+	config["iso_checksum_type"] = "none"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) == 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if b.config.ISOChecksumType != "none" {
+		t.Fatalf("should've lowercased: %s", b.config.ISOChecksumType)
+	}
+}
+
+func TestBuilderPrepare_ISOUrl(t *testing.T) {
+	var b Builder
+	config := testConfig()
+	delete(config, "iso_url")
+	delete(config, "iso_urls")
+
+	// Test both epty
+	config["iso_url"] = ""
+	b = Builder{}
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Test iso_url set
+	config["iso_url"] = "http://www.packer.io"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Errorf("should not have error: %s", err)
+	}
+
+	expected := []string{"http://www.packer.io"}
+	if !reflect.DeepEqual(b.config.ISOUrls, expected) {
+		t.Fatalf("bad: %#v", b.config.ISOUrls)
+	}
+
+	// Test both set
+	config["iso_url"] = "http://www.packer.io"
+	config["iso_urls"] = []string{"http://www.packer.io"}
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Test just iso_urls set
+	delete(config, "iso_url")
+	config["iso_urls"] = []string{
+		"http://www.packer.io",
+		"http://www.hashicorp.com",
+	}
+
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Errorf("should not have error: %s", err)
+	}
+
+	expected = []string{
+		"http://www.packer.io",
+		"http://www.hashicorp.com",
+	}
+	if !reflect.DeepEqual(b.config.ISOUrls, expected) {
+		t.Fatalf("bad: %#v", b.config.ISOUrls)
+	}
+}
+
+func TestBuilderPrepare_ParallelsToolsHostPath(t *testing.T) {
+	var b Builder
+	config := testConfig()
+	delete(config, "parallels_tools_host_path")
+
+	// Test that it is deprecated
+	config["parallels_tools_host_path"] = "/path/to/iso"
+	warns, err := b.Prepare(config)
+	if len(warns) == 0 {
+		t.Fatalf("should have warning")
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+}

--- a/builder/parallels-windows/iso/step_attach_iso.go
+++ b/builder/parallels-windows/iso/step_attach_iso.go
@@ -1,0 +1,70 @@
+package iso
+
+import (
+	"fmt"
+	"github.com/mitchellh/multistep"
+	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
+	"github.com/mitchellh/packer/packer"
+	"log"
+)
+
+// This step attaches the ISO to the virtual machine.
+//
+// Uses:
+//   driver Driver
+//   isoPath string
+//   ui packer.Ui
+//   vmName string
+//
+// Produces:
+//	 attachedIso bool
+type stepAttachISO struct{}
+
+func (s *stepAttachISO) Run(state multistep.StateBag) multistep.StepAction {
+	driver := state.Get("driver").(parallelscommon.Driver)
+	isoPath := state.Get("iso_path").(string)
+	ui := state.Get("ui").(packer.Ui)
+	vmName := state.Get("vmName").(string)
+
+	// Attach the disk to the cdrom0 device. We couldn't use a separated device because it is failed to boot in PD9 [GH-1667]
+	ui.Say("Attaching ISO to the default CD/DVD ROM device...")
+	command := []string{
+		"set", vmName,
+		"--device-set", "cdrom0",
+		"--image", isoPath,
+		"--enable", "--connect",
+	}
+	if err := driver.Prlctl(command...); err != nil {
+		err := fmt.Errorf("Error attaching ISO: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Set some state so we know to remove
+	state.Put("attachedIso", true)
+
+	return multistep.ActionContinue
+}
+
+func (s *stepAttachISO) Cleanup(state multistep.StateBag) {
+	if _, ok := state.GetOk("attachedIso"); !ok {
+		return
+	}
+
+	driver := state.Get("driver").(parallelscommon.Driver)
+	ui := state.Get("ui").(packer.Ui)
+	vmName := state.Get("vmName").(string)
+
+	// Detach ISO by setting an empty string image.
+	log.Println("Detaching ISO from the default CD/DVD ROM device...")
+	command := []string{
+		"set", vmName,
+		"--device-set", "cdrom0",
+		"--image", "", "--disconnect", "--enable",
+	}
+
+	if err := driver.Prlctl(command...); err != nil {
+		ui.Error(fmt.Sprintf("Error detaching ISO: %s", err))
+	}
+}

--- a/builder/parallels-windows/iso/step_create_disk.go
+++ b/builder/parallels-windows/iso/step_create_disk.go
@@ -1,0 +1,40 @@
+package iso
+
+import (
+	"fmt"
+	"github.com/mitchellh/multistep"
+	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
+	"github.com/mitchellh/packer/packer"
+	"strconv"
+)
+
+// This step creates the virtual disk that will be used as the
+// hard drive for the virtual machine.
+type stepCreateDisk struct{}
+
+func (s *stepCreateDisk) Run(state multistep.StateBag) multistep.StepAction {
+	config := state.Get("config").(*config)
+	driver := state.Get("driver").(parallelscommon.Driver)
+	ui := state.Get("ui").(packer.Ui)
+	vmName := state.Get("vmName").(string)
+
+	command := []string{
+		"set", vmName,
+		"--device-add", "hdd",
+		"--size", strconv.FormatUint(uint64(config.DiskSize), 10),
+		"--iface", config.HardDriveInterface,
+	}
+
+	ui.Say("Creating hard drive...")
+	err := driver.Prlctl(command...)
+	if err != nil {
+		err := fmt.Errorf("Error creating hard drive: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepCreateDisk) Cleanup(state multistep.StateBag) {}

--- a/builder/parallels-windows/iso/step_create_vm.go
+++ b/builder/parallels-windows/iso/step_create_vm.go
@@ -1,0 +1,76 @@
+package iso
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/multistep"
+	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
+	"github.com/mitchellh/packer/packer"
+)
+
+// This step creates the actual virtual machine.
+//
+// Produces:
+//   vmName string - The name of the VM
+type stepCreateVM struct {
+	vmName string
+}
+
+func (s *stepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
+
+	config := state.Get("config").(*config)
+	driver := state.Get("driver").(parallelscommon.Driver)
+	ui := state.Get("ui").(packer.Ui)
+	name := config.VMName
+
+	commands := make([][]string, 8)
+	commands[0] = []string{
+		"create", name,
+		"--distribution", config.GuestOSType,
+		"--dst", config.OutputDir,
+		"--vmtype", "vm",
+		"--no-hdd",
+	}
+	commands[1] = []string{"set", name, "--cpus", "1"}
+	commands[2] = []string{"set", name, "--memsize", "512"}
+	commands[3] = []string{"set", name, "--startup-view", "same"}
+	commands[4] = []string{"set", name, "--on-shutdown", "close"}
+	commands[5] = []string{"set", name, "--on-window-close", "keep-running"}
+	commands[6] = []string{"set", name, "--auto-share-camera", "off"}
+	commands[7] = []string{"set", name, "--smart-guard", "off"}
+
+	ui.Say("Creating virtual machine...")
+	for _, command := range commands {
+		err := driver.Prlctl(command...)
+		ui.Say(fmt.Sprintf("Executing: prlctl %s", command))
+		if err != nil {
+			err := fmt.Errorf("Error creating VM: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+		// Set the VM name property on the first command
+		if s.vmName == "" {
+			s.vmName = name
+		}
+	}
+
+	// Set the final name in the state bag so others can use it
+	state.Put("vmName", s.vmName)
+	return multistep.ActionContinue
+}
+
+func (s *stepCreateVM) Cleanup(state multistep.StateBag) {
+	if s.vmName == "" {
+		return
+	}
+
+	driver := state.Get("driver").(parallelscommon.Driver)
+	ui := state.Get("ui").(packer.Ui)
+
+	ui.Say("Unregistering virtual machine...")
+	if err := driver.Prlctl("unregister", s.vmName); err != nil {
+		ui.Error(fmt.Sprintf("Error unregistering virtual machine: %s", err))
+	}
+}

--- a/builder/parallels-windows/iso/step_http_server.go
+++ b/builder/parallels-windows/iso/step_http_server.go
@@ -1,0 +1,76 @@
+package iso
+
+import (
+	"fmt"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+	"log"
+	"math/rand"
+	"net"
+	"net/http"
+)
+
+// This step creates and runs the HTTP server that is serving files from the
+// directory specified by the 'http_directory` configuration parameter in the
+// template.
+//
+// Uses:
+//   config *config
+//   ui     packer.Ui
+//
+// Produces:
+//   http_port int - The port the HTTP server started on.
+type stepHTTPServer struct {
+	l net.Listener
+}
+
+func (s *stepHTTPServer) Run(state multistep.StateBag) multistep.StepAction {
+	config := state.Get("config").(*config)
+	ui := state.Get("ui").(packer.Ui)
+
+	var httpPort uint = 0
+	if config.HTTPDir == "" {
+		state.Put("http_port", httpPort)
+		return multistep.ActionContinue
+	}
+
+	// Find an available TCP port for our HTTP server
+	var httpAddr string
+	portRange := int(config.HTTPPortMax - config.HTTPPortMin)
+	for {
+		var err error
+		var offset uint = 0
+
+		if portRange > 0 {
+			// Intn will panic if portRange == 0, so we do a check.
+			offset = uint(rand.Intn(portRange))
+		}
+
+		httpPort = offset + config.HTTPPortMin
+		httpAddr = fmt.Sprintf(":%d", httpPort)
+		log.Printf("Trying port: %d", httpPort)
+		s.l, err = net.Listen("tcp", httpAddr)
+		if err == nil {
+			break
+		}
+	}
+
+	ui.Say(fmt.Sprintf("Starting HTTP server on port %d", httpPort))
+
+	// Start the HTTP server and run it in the background
+	fileServer := http.FileServer(http.Dir(config.HTTPDir))
+	server := &http.Server{Addr: httpAddr, Handler: fileServer}
+	go server.Serve(s.l)
+
+	// Save the address into the state so it can be accessed in the future
+	state.Put("http_port", httpPort)
+
+	return multistep.ActionContinue
+}
+
+func (s *stepHTTPServer) Cleanup(multistep.StateBag) {
+	if s.l != nil {
+		// Close the listener so that the HTTP server stops
+		s.l.Close()
+	}
+}

--- a/builder/parallels-windows/iso/step_set_boot_order.go
+++ b/builder/parallels-windows/iso/step_set_boot_order.go
@@ -1,0 +1,42 @@
+package iso
+
+import (
+	"fmt"
+	"github.com/mitchellh/multistep"
+	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
+	"github.com/mitchellh/packer/packer"
+)
+
+// This step sets the device boot order for the virtual machine.
+//
+// Uses:
+//   driver Driver
+//   ui packer.Ui
+//   vmName string
+//
+// Produces:
+type stepSetBootOrder struct{}
+
+func (s *stepSetBootOrder) Run(state multistep.StateBag) multistep.StepAction {
+	driver := state.Get("driver").(parallelscommon.Driver)
+	ui := state.Get("ui").(packer.Ui)
+	vmName := state.Get("vmName").(string)
+
+	// Set new boot order
+	ui.Say("Setting the boot order...")
+	command := []string{
+		"set", vmName,
+		"--device-bootorder", fmt.Sprintf("hdd0 cdrom0 net0"),
+	}
+
+	if err := driver.Prlctl(command...); err != nil {
+		err := fmt.Errorf("Error setting the boot order: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepSetBootOrder) Cleanup(state multistep.StateBag) {}

--- a/builder/parallels-windows/pvm/builder.go
+++ b/builder/parallels-windows/pvm/builder.go
@@ -1,0 +1,135 @@
+package pvm
+
+import (
+	"errors"
+	"fmt"
+	"github.com/mitchellh/multistep"
+	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
+	"github.com/mitchellh/packer/common"
+	"github.com/mitchellh/packer/packer"
+	winparallelscommon "github.com/packer-community/packer-windows-plugins/builder/parallels-windows/common"
+	"log"
+)
+
+// Builder implements packer.Builder and builds the actual Parallels
+// images.
+type Builder struct {
+	config *Config
+	runner multistep.Runner
+}
+
+// Prepare processes the build configuration parameters.
+func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
+	c, warnings, errs := NewConfig(raws...)
+	if errs != nil {
+		return warnings, errs
+	}
+	b.config = c
+
+	return warnings, nil
+}
+
+// Run executes a Packer build and returns a packer.Artifact representing
+// a Parallels appliance.
+func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packer.Artifact, error) {
+	// Create the driver that we'll use to communicate with Parallels
+	driver, err := parallelscommon.NewDriver()
+	if err != nil {
+		return nil, fmt.Errorf("Failed creating Paralles driver: %s", err)
+	}
+
+	// Set up the state.
+	state := new(multistep.BasicStateBag)
+	state.Put("config", b.config)
+	state.Put("driver", driver)
+	state.Put("hook", hook)
+	state.Put("ui", ui)
+	state.Put("http_port", uint(0))
+
+	// Build the steps.
+	steps := []multistep.Step{
+		&parallelscommon.StepPrepareParallelsTools{
+			ParallelsToolsMode:   b.config.ParallelsToolsMode,
+			ParallelsToolsFlavor: b.config.ParallelsToolsFlavor,
+		},
+		&parallelscommon.StepOutputDir{
+			Force: b.config.PackerForce,
+			Path:  b.config.OutputDir,
+		},
+		&common.StepCreateFloppy{
+			Files: b.config.FloppyFiles,
+		},
+		&StepImport{
+			Name:       b.config.VMName,
+			SourcePath: b.config.SourcePath,
+		},
+		&parallelscommon.StepAttachParallelsTools{
+			ParallelsToolsMode: b.config.ParallelsToolsMode,
+		},
+		new(parallelscommon.StepAttachFloppy),
+		&parallelscommon.StepPrlctl{
+			Commands: b.config.Prlctl,
+			Tpl:      b.config.tpl,
+		},
+		&parallelscommon.StepRun{
+			BootWait: b.config.BootWait,
+			Headless: b.config.Headless,
+		},
+		&parallelscommon.StepTypeBootCommand{
+			BootCommand:    b.config.BootCommand,
+			HostInterfaces: []string{},
+			VMName:         b.config.VMName,
+			Tpl:            b.config.tpl,
+		},
+		winparallelscommon.NewConnectStep(b.config.WinRMConfig),
+		&parallelscommon.StepUploadVersion{
+			Path: b.config.PrlctlVersionFile,
+		},
+		&parallelscommon.StepUploadParallelsTools{
+			ParallelsToolsFlavor:    b.config.ParallelsToolsFlavor,
+			ParallelsToolsGuestPath: b.config.ParallelsToolsGuestPath,
+			ParallelsToolsMode:      b.config.ParallelsToolsMode,
+			Tpl:                     b.config.tpl,
+		},
+		new(common.StepProvision),
+		&parallelscommon.StepShutdown{
+			Command: b.config.ShutdownCommand,
+			Timeout: b.config.ShutdownTimeout,
+		},
+	}
+
+	// Run the steps.
+	if b.config.PackerDebug {
+		b.runner = &multistep.DebugRunner{
+			Steps:   steps,
+			PauseFn: common.MultistepDebugFn(ui),
+		}
+	} else {
+		b.runner = &multistep.BasicRunner{Steps: steps}
+	}
+	b.runner.Run(state)
+
+	// Report any errors.
+	if rawErr, ok := state.GetOk("error"); ok {
+		return nil, rawErr.(error)
+	}
+
+	// If we were interrupted or cancelled, then just exit.
+	if _, ok := state.GetOk(multistep.StateCancelled); ok {
+		return nil, errors.New("Build was cancelled.")
+	}
+
+	if _, ok := state.GetOk(multistep.StateHalted); ok {
+		return nil, errors.New("Build was halted.")
+	}
+
+	return parallelscommon.NewArtifact(b.config.OutputDir)
+}
+
+// Cancel.
+func (b *Builder) Cancel() {
+	if b.runner != nil {
+		log.Println("Cancelling the step runner...")
+		b.runner.Cancel()
+	}
+}

--- a/builder/parallels-windows/pvm/config.go
+++ b/builder/parallels-windows/pvm/config.go
@@ -1,0 +1,105 @@
+package pvm
+
+import (
+	"fmt"
+	"os"
+
+	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
+	"github.com/mitchellh/packer/common"
+	"github.com/mitchellh/packer/packer"
+	wincommon "github.com/packer-community/packer-windows-plugins/common"
+)
+
+// Config is the configuration structure for the builder.
+type Config struct {
+	common.PackerConfig                 `mapstructure:",squash"`
+	parallelscommon.FloppyConfig        `mapstructure:",squash"`
+	parallelscommon.OutputConfig        `mapstructure:",squash"`
+	parallelscommon.PrlctlConfig        `mapstructure:",squash"`
+	parallelscommon.PrlctlVersionConfig `mapstructure:",squash"`
+	parallelscommon.RunConfig           `mapstructure:",squash"`
+	parallelscommon.ShutdownConfig      `mapstructure:",squash"`
+	parallelscommon.ToolsConfig         `mapstructure:",squash"`
+	wincommon.WinRMConfig               `mapstructure:",squash"`
+
+	BootCommand []string `mapstructure:"boot_command"`
+	SourcePath  string   `mapstructure:"source_path"`
+	VMName      string   `mapstructure:"vm_name"`
+	ReassignMac bool     `mapstructure:"reassign_mac"`
+
+	tpl *packer.ConfigTemplate
+}
+
+func NewConfig(raws ...interface{}) (*Config, []string, error) {
+	c := new(Config)
+	md, err := common.DecodeConfig(c, raws...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c.tpl, err = packer.NewConfigTemplate()
+	if err != nil {
+		return nil, nil, err
+	}
+	c.tpl.UserVars = c.PackerUserVars
+
+	if c.VMName == "" {
+		c.VMName = fmt.Sprintf("packer-%s-{{timestamp}}", c.PackerBuildName)
+	}
+
+	// Prepare the errors
+	errs := common.CheckUnusedConfig(md)
+	errs = packer.MultiErrorAppend(errs, c.FloppyConfig.Prepare(c.tpl)...)
+	errs = packer.MultiErrorAppend(errs, c.OutputConfig.Prepare(c.tpl, &c.PackerConfig)...)
+	errs = packer.MultiErrorAppend(errs, c.PrlctlConfig.Prepare(c.tpl)...)
+	errs = packer.MultiErrorAppend(errs, c.PrlctlVersionConfig.Prepare(c.tpl)...)
+	errs = packer.MultiErrorAppend(errs, c.RunConfig.Prepare(c.tpl)...)
+	errs = packer.MultiErrorAppend(errs, c.ShutdownConfig.Prepare(c.tpl)...)
+	errs = packer.MultiErrorAppend(errs, c.WinRMConfig.Prepare(c.tpl)...)
+	errs = packer.MultiErrorAppend(errs, c.ToolsConfig.Prepare(c.tpl)...)
+
+	templates := map[string]*string{
+		"source_path": &c.SourcePath,
+		"vm_name":     &c.VMName,
+	}
+
+	for n, ptr := range templates {
+		var err error
+		*ptr, err = c.tpl.Process(*ptr, nil)
+		if err != nil {
+			errs = packer.MultiErrorAppend(
+				errs, fmt.Errorf("Error processing %s: %s", n, err))
+		}
+	}
+
+	for i, command := range c.BootCommand {
+		if err := c.tpl.Validate(command); err != nil {
+			errs = packer.MultiErrorAppend(errs,
+				fmt.Errorf("Error processing boot_command[%d]: %s", i, err))
+		}
+	}
+
+	if c.SourcePath == "" {
+		errs = packer.MultiErrorAppend(errs, fmt.Errorf("source_path is required"))
+	} else {
+		if _, err := os.Stat(c.SourcePath); err != nil {
+			errs = packer.MultiErrorAppend(errs,
+				fmt.Errorf("source_path is invalid: %s", err))
+		}
+	}
+
+	// Warnings
+	var warnings []string
+	if c.ShutdownCommand == "" {
+		warnings = append(warnings,
+			"A shutdown_command was not specified. Without a shutdown command, Packer\n"+
+				"will forcibly halt the virtual machine, which may result in data loss.")
+	}
+
+	// Check for any errors.
+	if errs != nil && len(errs.Errors) > 0 {
+		return nil, warnings, errs
+	}
+
+	return c, warnings, nil
+}

--- a/builder/parallels-windows/pvm/config_test.go
+++ b/builder/parallels-windows/pvm/config_test.go
@@ -1,0 +1,87 @@
+package pvm
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func testConfig(t *testing.T) map[string]interface{} {
+	return map[string]interface{}{
+		"winrm_username":         "foo",
+		"winrm_password":         "foo",
+		"shutdown_command":       "foo",
+		"parallels_tools_flavor": "lin",
+	}
+}
+
+func getTempFile(t *testing.T) *os.File {
+	tf, err := ioutil.TempFile("", "packer")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	tf.Close()
+
+	// don't forget to cleanup the file downstream:
+	// defer os.Remove(tf.Name())
+
+	return tf
+}
+
+func testConfigErr(t *testing.T, warns []string, err error) {
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should error")
+	}
+}
+
+func testConfigOk(t *testing.T, warns []string, err error) {
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+}
+
+func TestNewConfig_sourcePath(t *testing.T) {
+	// Bad
+	c := testConfig(t)
+	delete(c, "source_path")
+	_, warns, errs := NewConfig(c)
+	testConfigErr(t, warns, errs)
+
+	// Bad
+	c = testConfig(t)
+	c["source_path"] = "/i/dont/exist"
+	_, warns, errs = NewConfig(c)
+	testConfigErr(t, warns, errs)
+
+	// Good
+	tf := getTempFile(t)
+	defer os.Remove(tf.Name())
+
+	c = testConfig(t)
+	c["source_path"] = tf.Name()
+	_, warns, errs = NewConfig(c)
+	testConfigOk(t, warns, errs)
+}
+
+func TestNewConfig_shutdown_timeout(t *testing.T) {
+	c := testConfig(t)
+	tf := getTempFile(t)
+	defer os.Remove(tf.Name())
+
+	// Expect this to fail
+	c["source_path"] = tf.Name()
+	c["shutdown_timeout"] = "NaN"
+	_, warns, errs := NewConfig(c)
+	testConfigErr(t, warns, errs)
+
+	// Passes when given a valid time duration
+	c["shutdown_timeout"] = "10s"
+	_, warns, errs = NewConfig(c)
+	testConfigOk(t, warns, errs)
+}

--- a/builder/parallels-windows/pvm/step_import.go
+++ b/builder/parallels-windows/pvm/step_import.go
@@ -1,0 +1,48 @@
+package pvm
+
+import (
+	"fmt"
+	"github.com/mitchellh/multistep"
+	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
+	"github.com/mitchellh/packer/packer"
+)
+
+// This step imports an PVM VM into Parallels.
+type StepImport struct {
+	Name       string
+	SourcePath string
+	vmName     string
+}
+
+func (s *StepImport) Run(state multistep.StateBag) multistep.StepAction {
+	driver := state.Get("driver").(parallelscommon.Driver)
+	ui := state.Get("ui").(packer.Ui)
+	config := state.Get("config").(*Config)
+
+	ui.Say(fmt.Sprintf("Importing VM: %s", s.SourcePath))
+	if err := driver.Import(s.Name, s.SourcePath, config.OutputDir, config.ReassignMac); err != nil {
+		err := fmt.Errorf("Error importing VM: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	s.vmName = s.Name
+	state.Put("vmName", s.Name)
+	return multistep.ActionContinue
+}
+
+func (s *StepImport) Cleanup(state multistep.StateBag) {
+
+	if s.vmName == "" {
+		return
+	}
+
+	driver := state.Get("driver").(parallelscommon.Driver)
+	ui := state.Get("ui").(packer.Ui)
+
+	ui.Say("Unregistering virtual machine...")
+	if err := driver.Prlctl("unregister", s.vmName); err != nil {
+		ui.Error(fmt.Sprintf("Error unregistering virtual machine: %s", err))
+	}
+}

--- a/builder/parallels-windows/pvm/step_test.go
+++ b/builder/parallels-windows/pvm/step_test.go
@@ -1,0 +1,19 @@
+package pvm
+
+import (
+	"bytes"
+	"github.com/mitchellh/multistep"
+	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
+	"github.com/mitchellh/packer/packer"
+	"testing"
+)
+
+func testState(t *testing.T) multistep.StateBag {
+	state := new(multistep.BasicStateBag)
+	state.Put("driver", new(parallelscommon.DriverMock))
+	state.Put("ui", &packer.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	})
+	return state
+}

--- a/builder/virtualbox-windows/common/connect_step.go
+++ b/builder/virtualbox-windows/common/connect_step.go
@@ -26,7 +26,7 @@ func WinRMAddressFunc(config wincommon.WinRMConfig) func(state multistep.StateBa
 	}
 }
 
-// Creates a generic SSH or WinRM connect step from a VMWare builder config
+// Creates a generic WinRM connect step from a Virtualbox builder config
 func NewConnectStep(winrmConfig wincommon.WinRMConfig) multistep.Step {
 	return &wincommon.StepConnectWinRM{
 		WinRMAddress:     WinRMAddressFunc(winrmConfig),

--- a/plugin/builder-parallels-windows-iso/main.go
+++ b/plugin/builder-parallels-windows-iso/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/mitchellh/packer/packer/plugin"
+	"github.com/packer-community/packer-windows-plugins/builder/parallels-windows/iso"
+)
+
+func main() {
+	server, err := plugin.Server()
+	if err != nil {
+		panic(err)
+	}
+	server.RegisterBuilder(new(iso.Builder))
+	server.Serve()
+}

--- a/plugin/builder-parallels-windows-pvm/main.go
+++ b/plugin/builder-parallels-windows-pvm/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/mitchellh/packer/packer/plugin"
+	"github.com/packer-community/packer-windows-plugins/builder/parallels-windows/pvm"
+)
+
+func main() {
+	server, err := plugin.Server()
+	if err != nil {
+		panic(err)
+	}
+	server.RegisterBuilder(new(pvm.Builder))
+	server.Serve()
+}


### PR DESCRIPTION
Added support for Parallels using ISO and PVM builders. 

No port forwarding is performed as per other builders, instead the boxes are addressed via unique IP addresses by querying the Parallels driver.