### PR TITLE
Restart Windows Provisioner

### DIFF
--- a/plugin/provisioner-restart-windows/main.go
+++ b/plugin/provisioner-restart-windows/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/mitchellh/packer/packer/plugin"
+	restartwindows "github.com/packer-community/packer-windows-plugins/provisioner/restart"
+)
+
+func main() {
+
+	server, err := plugin.Server()
+	if err != nil {
+		panic(err)
+	}
+	server.RegisterProvisioner(new(restartwindows.Provisioner))
+	server.Serve()
+}

--- a/provisioner/restart/provisioner.go
+++ b/provisioner/restart/provisioner.go
@@ -1,0 +1,124 @@
+package restart
+
+import (
+	"fmt"
+	//"github.com/masterzen/winrm/winrm"
+	"github.com/mitchellh/packer/common"
+	"github.com/mitchellh/packer/packer"
+	"log"
+	"os"
+	"time"
+)
+
+var DefaultRestartCommand = "shutdown /r /c \"packer restart\" /t 5 && net stop winrm"
+
+var retryableSleep = 2 * time.Second
+
+type config struct {
+	common.PackerConfig `mapstructure:",squash"`
+
+	// The command used to execute the script. The '{{ .Path }}' variable
+	// should be used to specify where the script goes, {{ .Vars }}
+	// can be used to inject the environment_vars into the environment.
+	RestartCommand string `mapstructure:"restart_command"`
+
+	// The timeout for retrying to start the process. Until this timeout
+	// is reached, if the provisioner can't start a process, it retries.
+	// This can be set high to allow for reboots.
+	RawStartRetryTimeout string `mapstructure:"start_retry_timeout"`
+	startRetryTimeout    time.Duration
+	tpl                  *packer.ConfigTemplate
+}
+
+type Provisioner struct {
+	config config
+}
+
+func (p *Provisioner) Prepare(raws ...interface{}) error {
+	md, err := common.DecodeConfig(&p.config, raws...)
+	if err != nil {
+		return err
+	}
+
+	p.config.tpl, err = packer.NewConfigTemplate()
+	if err != nil {
+		return err
+	}
+	p.config.tpl.UserVars = p.config.PackerUserVars
+
+	// Accumulate any errors
+	errs := common.CheckUnusedConfig(md)
+
+	if p.config.RestartCommand == "" {
+		p.config.RestartCommand = DefaultRestartCommand
+	}
+
+	if p.config.RawStartRetryTimeout == "" {
+		p.config.RawStartRetryTimeout = "5m"
+	}
+
+	if p.config.RawStartRetryTimeout != "" {
+		p.config.startRetryTimeout, err = time.ParseDuration(p.config.RawStartRetryTimeout)
+		if err != nil {
+			errs = packer.MultiErrorAppend(
+				errs, fmt.Errorf("Failed parsing start_retry_timeout: %s", err))
+		}
+	}
+
+	if errs != nil && len(errs.Errors) > 0 {
+		return errs
+	}
+
+	return nil
+}
+
+func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
+	ui.Say("Restarting Windows Machine")
+
+	var cmd *packer.RemoteCmd
+	command := DefaultRestartCommand
+	err := p.retryable(func() error {
+		cmd = &packer.RemoteCmd{Command: command}
+		return cmd.StartWithUi(comm, ui)
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if cmd.ExitStatus != 0 {
+		return fmt.Errorf("Restart script exited with non-zero exit status: %d", cmd.ExitStatus)
+	}
+
+	return nil
+}
+
+func (p *Provisioner) Cancel() {
+	os.Exit(0)
+}
+
+// retryable will retry the given function over and over until a
+// non-error is returned.
+func (p *Provisioner) retryable(f func() error) error {
+	startTimeout := time.After(p.config.startRetryTimeout)
+	for {
+		var err error
+		if err = f(); err == nil {
+			return nil
+		}
+
+		// Create an error and log it
+		err = fmt.Errorf("Retryable error: %s", err)
+		log.Printf(err.Error())
+
+		// Check if we timed out, otherwise we retry. It is safe to
+		// retry since the only error case above is if the command
+		// failed to START.
+		select {
+		case <-startTimeout:
+			return err
+		default:
+			time.Sleep(retryableSleep)
+		}
+	}
+}

--- a/provisioner/restart/provisioner.go
+++ b/provisioner/restart/provisioner.go
@@ -102,8 +102,7 @@ var waitForRestart = func(p *Provisioner) error {
 	ui := p.ui
 	ui.Say("Waiting for machine to restart...")
 	waitDone := make(chan bool, 1)
-	timeoutDuration := 1 * time.Minute
-	timeout := time.After(timeoutDuration)
+	timeout := time.After(p.config.startRetryTimeout)
 	var err error
 
 	go func() {
@@ -112,7 +111,7 @@ var waitForRestart = func(p *Provisioner) error {
 		waitDone <- true
 	}()
 
-	log.Printf("Waiting for machine to reboot with timeout: %s", timeoutDuration)
+	log.Printf("Waiting for machine to reboot with timeout: %s", p.config.startRetryTimeout)
 
 WaitLoop:
 	for {

--- a/provisioner/restart/provisioner.go
+++ b/provisioner/restart/provisioner.go
@@ -56,6 +56,10 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		p.config.RestartCommand = DefaultRestartCommand
 	}
 
+	if p.config.RestartCheckCommand == "" {
+		p.config.RestartCheckCommand = DefaultRestartCheckCommand
+	}
+
 	if p.config.RawRestartTimeout == "" {
 		p.config.RawRestartTimeout = "5m"
 	}

--- a/provisioner/restart/provisioner_test.go
+++ b/provisioner/restart/provisioner_test.go
@@ -163,6 +163,7 @@ func TestProvisionerProvision_WaitForRestartFail(t *testing.T) {
 }
 
 func TestProvision_waitForRestartTimeout(t *testing.T) {
+	retryableSleep = 10 * time.Millisecond
 	config := testConfig()
 	config["restart_timeout"] = "1ms"
 	ui := testUi()

--- a/provisioner/restart/provisioner_test.go
+++ b/provisioner/restart/provisioner_test.go
@@ -218,6 +218,12 @@ func TestProvision_waitForCommunitactor(t *testing.T) {
 		t.Fatal("should not have error, got: %s", err.Error())
 	}
 
+	expectedCommand := DefaultRestartCheckCommand
+
+	// Should run the command without alteration
+	if comm.StartCmd.Command != expectedCommand {
+		t.Fatalf("Expect command to be: %s, got %s", expectedCommand, comm.StartCmd.Command)
+	}
 }
 
 func TestRetryable(t *testing.T) {

--- a/provisioner/restart/provisioner_test.go
+++ b/provisioner/restart/provisioner_test.go
@@ -1,0 +1,169 @@
+package restart
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/mitchellh/packer/packer"
+	"testing"
+	"time"
+)
+
+func testConfig() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func TestProvisioner_Impl(t *testing.T) {
+	var raw interface{}
+	raw = &Provisioner{}
+	if _, ok := raw.(packer.Provisioner); !ok {
+		t.Fatalf("must be a Provisioner")
+	}
+}
+
+func TestProvisionerPrepare_Defaults(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if p.config.RawStartRetryTimeout != "5m" {
+		t.Errorf("unexpected remote path: %s", p.config.RawStartRetryTimeout)
+	}
+
+	if p.config.RestartCommand != "shutdown /r /c \"packer restart\" /t 5 && net stop winrm" {
+		t.Errorf("unexpected remote path: %s", p.config.RestartCommand)
+	}
+
+	if p.config.startRetryTimeout != 5*time.Minute {
+		t.Errorf("Expected default startRetryTimeout to be 5 minutes")
+	}
+}
+
+func TestProvisionerPrepare_ConfigRetryTimeout(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+	config["start_retry_timeout"] = "1m"
+
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if p.config.RawStartRetryTimeout != "1m" {
+		t.Errorf("unexpected remote path: %s", p.config.RawStartRetryTimeout)
+	}
+
+	if p.config.startRetryTimeout != 1*time.Minute {
+		t.Errorf("Expected default startRetryTimeout to be 5 minutes")
+	}
+}
+
+func TestProvisionerPrepare_ConfigErrors(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+	config["start_retry_timeout"] = "m"
+
+	err := p.Prepare(config)
+	if err == nil {
+		t.Fatal("Expected error parsing start_retry_timeout but did not receive one.")
+	}
+}
+
+func TestProvisionerPrepare_InvalidKey(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	// Add a random key
+	config["i_should_not_be_valid"] = true
+	err := p.Prepare(config)
+	if err == nil {
+		t.Fatal("should have error")
+	}
+}
+
+func testUi() *packer.BasicUi {
+	return &packer.BasicUi{
+		Reader:      new(bytes.Buffer),
+		Writer:      new(bytes.Buffer),
+		ErrorWriter: new(bytes.Buffer),
+	}
+}
+
+func TestProvisionerProvision_Success(t *testing.T) {
+	config := testConfig()
+
+	// Defaults provided by Packer
+	ui := testUi()
+	p := new(Provisioner)
+
+	// Defaults provided by Packer
+	comm := new(packer.MockCommunicator)
+	p.Prepare(config)
+	err := p.Provision(ui, comm)
+	if err != nil {
+		t.Fatal("should not have error")
+	}
+
+	expectedCommand := DefaultRestartCommand
+
+	// Should run the command without alteration
+	if comm.StartCmd.Command != expectedCommand {
+		t.Fatalf("Expect command to be: %s, got %s", expectedCommand, comm.StartCmd.Command)
+	}
+}
+func TestProvisionerProvision_Fail(t *testing.T) {
+	config := testConfig()
+
+	// Defaults provided by Packer
+	ui := testUi()
+	p := new(Provisioner)
+
+	// Defaults provided by Packer
+	comm := new(packer.MockCommunicator)
+	comm.StartStderr = "WinRM terminated"
+	comm.StartExitStatus = 1
+	p.Prepare(config)
+	err := p.Provision(ui, comm)
+	if err == nil {
+		t.Fatal("should have error")
+	}
+}
+
+func TestRetryable(t *testing.T) {
+	config := testConfig()
+
+	count := 0
+	retryMe := func() error {
+		t.Logf("RetryMe, attempt number %d", count)
+		if count == 2 {
+			return nil
+		}
+		count++
+		return errors.New(fmt.Sprintf("Still waiting %d more times...", 2-count))
+	}
+	retryableSleep = 50 * time.Millisecond
+	p := new(Provisioner)
+	p.config.RawStartRetryTimeout = "155ms"
+	err := p.Prepare(config)
+	err = p.retryable(retryMe)
+	if err != nil {
+		t.Fatalf("should not have error retrying funuction")
+	}
+
+	count = 0
+	p.config.RawStartRetryTimeout = "10ms"
+	err = p.Prepare(config)
+	err = p.retryable(retryMe)
+	if err == nil {
+		t.Fatalf("should have error retrying funuction")
+	}
+}
+
+func TestCancel(t *testing.T) {
+	// Don't actually call Cancel() as it performs an os.Exit(0)
+	// which kills the 'go test' tool
+}

--- a/provisioner/restart/provisioner_test.go
+++ b/provisioner/restart/provisioner_test.go
@@ -30,46 +30,46 @@ func TestProvisionerPrepare_Defaults(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if p.config.RawStartRetryTimeout != "5m" {
-		t.Errorf("unexpected remote path: %s", p.config.RawStartRetryTimeout)
+	if p.config.RawRestartTimeout != "5m" {
+		t.Errorf("unexpected remote path: %s", p.config.RawRestartTimeout)
 	}
 
 	if p.config.RestartCommand != "shutdown /r /c \"packer restart\" /t 5 && net stop winrm" {
 		t.Errorf("unexpected remote path: %s", p.config.RestartCommand)
 	}
 
-	if p.config.startRetryTimeout != 5*time.Minute {
-		t.Errorf("Expected default startRetryTimeout to be 5 minutes")
+	if p.config.restartTimeout != 5*time.Minute {
+		t.Errorf("Expected default restartTimeout to be 5 minutes")
 	}
 }
 
 func TestProvisionerPrepare_ConfigRetryTimeout(t *testing.T) {
 	var p Provisioner
 	config := testConfig()
-	config["start_retry_timeout"] = "1m"
+	config["restart_timeout"] = "1m"
 
 	err := p.Prepare(config)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	if p.config.RawStartRetryTimeout != "1m" {
-		t.Errorf("unexpected remote path: %s", p.config.RawStartRetryTimeout)
+	if p.config.RawRestartTimeout != "1m" {
+		t.Errorf("unexpected remote path: %s", p.config.RawRestartTimeout)
 	}
 
-	if p.config.startRetryTimeout != 1*time.Minute {
-		t.Errorf("Expected default startRetryTimeout to be 5 minutes")
+	if p.config.restartTimeout != 1*time.Minute {
+		t.Errorf("Expected default restartTimeout to be 5 minutes")
 	}
 }
 
 func TestProvisionerPrepare_ConfigErrors(t *testing.T) {
 	var p Provisioner
 	config := testConfig()
-	config["start_retry_timeout"] = "m"
+	config["restart_timeout"] = "m"
 
 	err := p.Prepare(config)
 	if err == nil {
-		t.Fatal("Expected error parsing start_retry_timeout but did not receive one.")
+		t.Fatal("Expected error parsing restart_timeout but did not receive one.")
 	}
 }
 
@@ -164,7 +164,7 @@ func TestProvisionerProvision_WaitForRestartFail(t *testing.T) {
 
 func TestProvision_waitForRestartTimeout(t *testing.T) {
 	config := testConfig()
-	config["start_retry_timeout"] = "1ms"
+	config["restart_timeout"] = "1ms"
 	ui := testUi()
 	p := new(Provisioner)
 	comm := new(packer.MockCommunicator)
@@ -234,7 +234,7 @@ func TestRetryable(t *testing.T) {
 	}
 	retryableSleep = 50 * time.Millisecond
 	p := new(Provisioner)
-	p.config.RawStartRetryTimeout = "155ms"
+	p.config.RawRestartTimeout = "155ms"
 	err := p.Prepare(config)
 	err = p.retryable(retryMe)
 	if err != nil {
@@ -242,7 +242,7 @@ func TestRetryable(t *testing.T) {
 	}
 
 	count = 0
-	p.config.RawStartRetryTimeout = "10ms"
+	p.config.RawRestartTimeout = "10ms"
 	err = p.Prepare(config)
 	err = p.retryable(retryMe)
 	if err == nil {


### PR DESCRIPTION
It is often inevitable when installing software and configuring Windows environments that a restart will be required at some stage. Whilst it is possible to manually add to a `powershell` or `windows-shell` script, it can be a little bit tedious and certain race conditions can make it flakey.

For example, you need to kill WinRM reliably and issue a shutdown and restart of the computer - the former can be difficult to do reliably over WinRM for obvious reasons, and the latter can take some time before all processes are shutdown. Meanwhile, Packer can move on to the next provisioner and very occasionally it may move on to the next provisioner whilst a restart is in progress and this is where things get messy.

This Provisioner simplifies the user experience by creating a simple plugin that will both perform this restart and properly awaits the machine to restart before returning control to the following Provisioner.

Supported configuration parameters:
* `start_retry_timeout` which defaults to `5m`
* `restart_command` which defaults to `shutdown /r /c \"packer restart\" /t 5 && net stop winrm`. It shouldn't be necessary to modify this but is reasonable to do so.

Example Provisioner setup:

```json
...
    {
      "type": "powershell",
      "inline": [
        "\"Before restart awesome message\""
      ]
    },
    {
	  "type":"restart-windows"
    },
    {
      "type": "powershell",
      "inline": [
        "echo \"After restart - hooray!\""
      ]
    },
```

Example Output:

> ...
=> testbox: Starting the virtual machine...
==> testbox: Waiting 30s for boot...
==> testbox: Typing the boot command...
==> testbox: Waiting for WinRM to become available...
==> testbox: Connected to WinRM!
==> testbox: Uploading VirtualBox version info (4.3.20)
==> testbox: Provisioning with Powershell...
==> testbox: Provisioning with shell script: ./scripts/test.ps1
    testbox: Before restart awesome message
==> testbox: Restarting Windows Machine
==> testbox: Waiting for machine to restart...
    testbox: VAGRANT-2012-R2 restarted.
    testbox:
==> testbox: Machine successfully restarted, moving on
==> testbox: Provisioning with Powershell...
==> testbox: Provisioning with shell script: ./scripts/test2.ps1
    testbox: After restart - hooray!
    testbox:
==> testbox: Gracefully halting virtual machine...
==> testbox: Preparing to export machine.
...
