### PR TITLE
Elevated powershell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ Check out these projects for more detailed examples of Windows-centric Packer te
 - [joefitzgerald/packer-windows](https://github.com/joefitzgerald/packer-windows)
 - [box-cutter/windows-vm](https://github.com/box-cutter/windows-vm)
 
+### Running commands with Elevated privileges
+
+In certain situations, you may need to run commands with elevated privileges even if your `winrm_username` user is an Administrator, for example upgrading system packages like the .NET Framework.
+In these cases there are 2 additional keys provided on the `powershell` provisioner that you can supply that will enable this mode: `elevated_user` and `elevated_password`:
+
+```
+{
+  "type": "powershell",
+  "elevated_user":"vagrant",
+  "elevated_password":"vagrant",
+  "inline": [
+    "choco install netfx-4.5.2-devpack"
+  ]
+}
+```
+
 ### Community
 - **IRC**: `#packer-community` on Freenode.
 - **Slack**: packer.slack.com

--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -102,6 +102,7 @@ func (c *Communicator) newCopyClient() (*winrmcp.Winrmcp, error) {
 			User:     c.user,
 			Password: c.password,
 		},
+		OperationTimeout:      time.Minute * 5,
 		MaxOperationsPerShell: 15, // lowest common denominator
 	})
 }

--- a/communicator/winrm/communicator_test.go
+++ b/communicator/winrm/communicator_test.go
@@ -54,41 +54,6 @@ func TestStart(t *testing.T) {
 	}
 }
 
-func TestStartElevated(t *testing.T) {
-	// This test hits an already running Windows VM
-	// You can comment this line out temporarily during development
-	t.Skip()
-
-	comm, err := New(&winrm.Endpoint{"localhost", 5985}, "vagrant", "vagrant", time.Duration(1)*time.Minute)
-	if err != nil {
-		t.Fatalf("error connecting to WinRM: %s", err)
-	}
-
-	var cmd packer.RemoteCmd
-	var outWriter, errWriter bytes.Buffer
-
-	cmd.Command = "dir"
-	cmd.Stdout = &outWriter
-	cmd.Stderr = &errWriter
-
-	err = comm.StartElevated(&cmd)
-	if err != nil {
-		t.Fatalf("error starting cmd: %s", err)
-	}
-	cmd.Wait()
-
-	fmt.Println(outWriter.String())
-	fmt.Println(errWriter.String())
-
-	if err != nil {
-		t.Fatalf("error running cmd: %s", err)
-	}
-
-	if cmd.ExitStatus != 0 {
-		t.Fatalf("exit status was non-zero: %d", cmd.ExitStatus)
-	}
-}
-
 func TestUpload(t *testing.T) {
 	// This test hits an already running Windows VM
 	// You can comment this line out temporarily during development

--- a/provisioner/powershell/elevated.go
+++ b/provisioner/powershell/elevated.go
@@ -1,0 +1,87 @@
+package powershell
+
+import (
+	"text/template"
+)
+
+type elevatedOptions struct {
+	User            string
+	Password        string
+	TaskName        string
+	TaskDescription string
+	EncodedCommand  string
+}
+
+var elevatedTemplate = template.Must(template.New("ElevatedCommand").Parse(`
+$name = "{{.TaskName}}"
+$log = "$env:TEMP\$name.out"
+$s = New-Object -ComObject "Schedule.Service"
+$s.Connect()
+$t = $s.NewTask($null)
+$t.XmlText = @'
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+	<Description>{{.TaskDescription}}</Description>
+  </RegistrationInfo>
+  <Principals>
+    <Principal id="Author">
+      <UserId>{{.User}}</UserId>
+      <LogonType>Password</LogonType>
+      <RunLevel>HighestAvailable</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>false</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>true</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT2H</ExecutionTimeLimit>
+    <Priority>4</Priority>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>cmd</Command>
+	  <Arguments>/c powershell.exe -EncodedCommand {{.EncodedCommand}} &gt; %TEMP%\{{.TaskName}}.out 2&gt;&amp;1</Arguments>
+    </Exec>
+  </Actions>
+</Task>
+'@
+$f = $s.GetFolder("\")
+$f.RegisterTaskDefinition($name, $t, 6, "{{.User}}", "{{.Password}}", 1, $null) | Out-Null
+$t = $f.GetTask("\$name")
+$t.Run($null) | Out-Null
+$timeout = 10
+$sec = 0
+while ((!($t.state -eq 4)) -and ($sec -lt $timeout)) {
+  Start-Sleep -s 1
+  $sec++
+}
+function SlurpOutput($l) {
+  if (Test-Path $log) {
+    Get-Content $log | select -skip $l | ForEach {
+      $l += 1
+      Write-Host "$_"
+    }
+  }
+  return $l
+}
+$line = 0
+do {
+  Start-Sleep -m 100
+  $line = SlurpOutput $line
+} while (!($t.state -eq 3))
+$result = $t.LastTaskResult
+[System.Runtime.Interopservices.Marshal]::ReleaseComObject($s) | Out-Null
+exit $result`))

--- a/provisioner/powershell/powershell.go
+++ b/provisioner/powershell/powershell.go
@@ -1,0 +1,17 @@
+package powershell
+
+import (
+	"encoding/base64"
+)
+
+func powershellEncode(buffer []byte) string {
+	// 2 byte chars to make PowerShell happy
+	wideCmd := ""
+	for _, b := range buffer {
+		wideCmd += string(b) + "\x00"
+	}
+
+	// Base64 encode the command
+	input := []uint8(wideCmd)
+	return base64.StdEncoding.EncodeToString(input)
+}

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -53,6 +53,11 @@ type config struct {
 	// can be used to inject the environment_vars into the environment.
 	ExecuteCommand string `mapstructure:"execute_command"`
 
+	// The command used to execute the elevated script. The '{{ .Path }}' variable
+	// should be used to specify where the script goes, {{ .Vars }}
+	// can be used to inject the environment_vars into the environment.
+	ElevatedExecuteCommand string `mapstructure:"elevated_execute_command"`
+
 	// The timeout for retrying to start the process. Until this timeout
 	// is reached, if the provisioner can't start a process, it retries.
 	// This can be set high to allow for reboots.
@@ -61,6 +66,10 @@ type config struct {
 	// This is used in the template generation to format environment variables
 	// inside the `ExecuteCommand` template.
 	EnvVarFormat string
+
+	// This is used in the template generation to format environment variables
+	// inside the `ElevatedExecuteCommand` template.
+	ElevatedEnvVarFormat string `mapstructure:"elevated_env_var_format"`
 
 	// Instructs the communicator to run the remote script as a
 	// Windows scheduled task, effectively elevating the remote
@@ -73,7 +82,8 @@ type config struct {
 }
 
 type Provisioner struct {
-	config config
+	config       config
+	communicator packer.Communicator
 }
 
 type ExecuteCommandTemplate struct {
@@ -100,8 +110,16 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		p.config.EnvVarFormat = `$env:%s=\"%s\"; `
 	}
 
+	if p.config.ElevatedEnvVarFormat == "" {
+		p.config.ElevatedEnvVarFormat = `$env:%s="%s"; `
+	}
+
 	if p.config.ExecuteCommand == "" {
 		p.config.ExecuteCommand = `powershell "& { {{.Vars}}{{.Path}} }"`
+	}
+
+	if p.config.ElevatedExecuteCommand == "" {
+		p.config.ElevatedExecuteCommand = `{{.Vars}}{{.Path}}`
 	}
 
 	if p.config.Inline != nil && len(p.config.Inline) == 0 {
@@ -127,6 +145,16 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	if p.config.Script != "" && len(p.config.Scripts) > 0 {
 		errs = packer.MultiErrorAppend(errs,
 			errors.New("Only one of script or scripts can be specified."))
+	}
+
+	if p.config.ElevatedUser != "" && p.config.ElevatedPassword == "" {
+		errs = packer.MultiErrorAppend(errs,
+			errors.New("Must supply an 'elevated_password' if 'elevated_user' provided"))
+	}
+
+	if p.config.ElevatedUser == "" && p.config.ElevatedPassword != "" {
+		errs = packer.MultiErrorAppend(errs,
+			errors.New("Must supply an 'elevated_user' if 'elevated_password' provided"))
 	}
 
 	if p.config.Script != "" {
@@ -210,9 +238,9 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 func extractScript(p *Provisioner) (string, error) {
 	temp, err := ioutil.TempFile(os.TempDir(), "packer-powershell-provisioner")
 	if err != nil {
-		log.Printf("Unable to create temporary file for inline scripts: %s", err)
 		return "", err
 	}
+	defer temp.Close()
 	writer := bufio.NewWriter(temp)
 	for _, command := range p.config.Inline {
 		log.Printf("Found command: %s", command)
@@ -225,13 +253,12 @@ func extractScript(p *Provisioner) (string, error) {
 		return "", fmt.Errorf("Error preparing shell script: %s", err)
 	}
 
-	temp.Close()
-
 	return temp.Name(), nil
 }
 
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	ui.Say(fmt.Sprintf("Provisioning with Powershell..."))
+	p.communicator = comm
 
 	scripts := make([]string, len(p.config.Scripts))
 	copy(scripts, p.config.Scripts)
@@ -260,13 +287,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		}
 		defer f.Close()
 
-		// Create environment variables to set before executing the command
-		flattendVars, err := p.createFlattenedEnvVars()
-		if err != nil {
-			return err
-		}
-
-		command, err := p.createCommandText(flattendVars)
+		command, err := p.createCommandText()
 		if err != nil {
 			return fmt.Errorf("Error processing command: %s", err)
 		}
@@ -336,7 +357,7 @@ func (p *Provisioner) retryable(f func() error) error {
 	}
 }
 
-func (p *Provisioner) createFlattenedEnvVars() (flattened string, err error) {
+func (p *Provisioner) createFlattenedEnvVars(elevated bool) (flattened string, err error) {
 	flattened = ""
 	envVars := make(map[string]string)
 
@@ -353,21 +374,32 @@ func (p *Provisioner) createFlattenedEnvVars() (flattened string, err error) {
 		}
 		envVars[keyValue[0]] = keyValue[1]
 	}
+
 	// Create a list of env var keys in sorted order
 	var keys []string
 	for k := range envVars {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
+	format := p.config.EnvVarFormat
+	if elevated {
+		format = p.config.ElevatedEnvVarFormat
+	}
+
 	// Re-assemble vars using OS specific format pattern and flatten
 	for _, key := range keys {
-		flattened += fmt.Sprintf(p.config.EnvVarFormat, key, envVars[key])
+		flattened += fmt.Sprintf(format, key, envVars[key])
 	}
 	return
 }
 
-func (p *Provisioner) createCommandText(flattenedEnvVars string) (string, error) {
-	command, err := p.config.tpl.Process(p.config.ExecuteCommand, &ExecuteCommandTemplate{
+func (p *Provisioner) createCommandText() (command string, err error) {
+	// Create environment variables to set before executing the command
+	flattenedEnvVars, err := p.createFlattenedEnvVars(false)
+	if err != nil {
+		return "", err
+	}
+	command, err = p.config.tpl.Process(p.config.ExecuteCommand, &ExecuteCommandTemplate{
 		Vars: flattenedEnvVars,
 		Path: p.config.RemotePath,
 	})
@@ -376,14 +408,30 @@ func (p *Provisioner) createCommandText(flattenedEnvVars string) (string, error)
 		return "", err
 	}
 
+	// Return the interpolated command
 	if p.config.ElevatedUser == "" {
 		return command, nil
 	}
 
-	// doesn't take well to the flattened env vars
-	command = "& " + p.config.RemotePath
+	// Can't double escape the env vars, lets create shiny new ones
+	flattenedEnvVars, err = p.createFlattenedEnvVars(true)
+	command, err = p.config.tpl.Process(p.config.ExecuteCommand, &ExecuteCommandTemplate{
+		Vars: flattenedEnvVars,
+		Path: p.config.RemotePath,
+	})
 
-	log.Printf("Building elevated command for: %s", command)
+	// OK so we need an elevated shell runner to wrap our command, this is going to have its own path
+	// generate the script and update the command runner in the process
+	path, err := p.generateElevatedRunner(command)
+
+	// Return the path to the elevated shell wrapper
+	command = fmt.Sprintf("powershell -executionpolicy bypass -file \"%s\"", path)
+
+	return
+}
+
+func (p *Provisioner) generateElevatedRunner(command string) (uploadedPath string, err error) {
+	log.Printf("Building elevated command wrapper for: %s", command)
 
 	// generate command
 	var buffer bytes.Buffer
@@ -396,9 +444,35 @@ func (p *Provisioner) createCommandText(flattenedEnvVars string) (string, error)
 	})
 
 	if err != nil {
+		fmt.Printf("Error creating elevated template: %s", err)
 		return "", err
 	}
 
-	//log.Printf("ELEVATED SCRIPT: %s\n\n", string(buffer.Bytes()))
-	return "powershell -EncodedCommand " + powershellEncode(buffer.Bytes()), nil
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "packer-elevated-shell.ps1")
+	writer := bufio.NewWriter(tmpFile)
+	if _, err := writer.WriteString(string(buffer.Bytes())); err != nil {
+		return "", fmt.Errorf("Error preparing elevated shell script: %s", err)
+	}
+
+	if err := writer.Flush(); err != nil {
+		return "", fmt.Errorf("Error preparing elevated shell script: %s", err)
+	}
+	tmpFile.Close()
+	f, err := os.Open(tmpFile.Name())
+	if err != nil {
+		return "", fmt.Errorf("Error opening temporary elevated shell script: %s", err)
+	}
+	defer f.Close()
+
+	uuid := uuid.TimeOrderedUUID()
+	path := fmt.Sprintf(`${env:TEMP}\packer-elevated-shell-%s.ps1`, uuid)
+	log.Printf("Uploading elevated shell wrapper for command [%s] to [%s] from [%s]", command, path, tmpFile.Name())
+	err = p.communicator.Upload(path, f, nil)
+	if err != nil {
+		return "", fmt.Errorf("Error preparing elevated shell script: %s", err)
+	}
+
+	// CMD formatted Path required for this op
+	path = fmt.Sprintf("%s-%s.ps1", "%TEMP%\\packer-elevated-shell", uuid)
+	return path, err
 }

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -15,8 +15,8 @@ import (
 	"time"
 
 	"github.com/mitchellh/packer/common"
+	"github.com/mitchellh/packer/common/uuid"
 	"github.com/mitchellh/packer/packer"
-	"github.com/packer/common/uuid"
 )
 
 const DefaultRemotePath = "c:/Windows/Temp/script.ps1"

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/mitchellh/packer/packer"
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/mitchellh/packer/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -59,6 +60,13 @@ func TestProvisionerPrepare_Defaults(t *testing.T) {
 
 	if p.config.RemotePath != DefaultRemotePath {
 		t.Errorf("unexpected remote path: %s", p.config.RemotePath)
+	}
+
+	if p.config.ElevatedUser != "" {
+		t.Error("expected elevated_user to be empty")
+	}
+	if p.config.ElevatedPassword != "" {
+		t.Error("expected elevated_password to be empty")
 	}
 
 	if p.config.ExecuteCommand != "powershell \"& { {{.Vars}}{{.Path}} }\"" {


### PR DESCRIPTION
Addresses #4 to allow elevated PowerShell scripts to work as advertised

*Tests*

Aside from unit tests, I have attempted the following minimal test case - installing the [.NET Devpack 4.5.2](http://www.microsoft.com/en-au/download/details.aspx?id=42637) package using Chocolatey: `choco install netfx-4.5.2-devpack`, across the following scenarios which requires elevated privileges to work:

* Windows 2012r2 Virtualbox OVF
* Windows 2008r2 Virtualbox OVF (with Windows updates pre-applied): https://gist.github.com/mefellows/bde689b1f0722a16c8a8. This also involved upgrading WMF to 4+ (using the elevated feature) to support Chocolatey install
* Amazon EBS instance (2012r2 AMI)