### PR TITLE
Issue/37

### DIFF
--- a/builder/amazon-windows/common/state.go
+++ b/builder/amazon-windows/common/state.go
@@ -1,0 +1,205 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"github.com/mitchellh/goamz/ec2"
+	"github.com/mitchellh/multistep"
+	"log"
+	"net"
+	"os"
+	"strconv"
+	"time"
+)
+
+// StateRefreshFunc is a function type used for StateChangeConf that is
+// responsible for refreshing the item being watched for a state change.
+//
+// It returns three results. `result` is any object that will be returned
+// as the final object after waiting for state change. This allows you to
+// return the final updated object, for example an EC2 instance after refreshing
+// it.
+//
+// `state` is the latest state of that object. And `err` is any error that
+// may have happened while refreshing the state.
+type StateRefreshFunc func() (result interface{}, state string, err error)
+
+// StateChangeConf is the configuration struct used for `WaitForState`.
+type StateChangeConf struct {
+	Pending   []string
+	Refresh   StateRefreshFunc
+	StepState multistep.StateBag
+	Target    string
+}
+
+// AMIStateRefreshFunc returns a StateRefreshFunc that is used to watch
+// an AMI for state changes.
+func AMIStateRefreshFunc(conn *ec2.EC2, imageId string) StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.Images([]string{imageId}, ec2.NewFilter())
+		if err != nil {
+			if ec2err, ok := err.(*ec2.Error); ok && ec2err.Code == "InvalidAMIID.NotFound" {
+				// Set this to nil as if we didn't find anything.
+				resp = nil
+			} else if isTransientNetworkError(err) {
+				// Transient network error, treat it as if we didn't find anything
+				resp = nil
+			} else {
+				log.Printf("Error on AMIStateRefresh: %s", err)
+				return nil, "", err
+			}
+		}
+
+		if resp == nil || len(resp.Images) == 0 {
+			// Sometimes AWS has consistency issues and doesn't see the
+			// AMI. Return an empty state.
+			return nil, "", nil
+		}
+
+		i := resp.Images[0]
+		return i, i.State, nil
+	}
+}
+
+// InstanceStateRefreshFunc returns a StateRefreshFunc that is used to watch
+// an EC2 instance.
+func InstanceStateRefreshFunc(conn *ec2.EC2, instanceId string) StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.Instances([]string{instanceId}, ec2.NewFilter())
+		if err != nil {
+			if ec2err, ok := err.(*ec2.Error); ok && ec2err.Code == "InvalidInstanceID.NotFound" {
+				// Set this to nil as if we didn't find anything.
+				resp = nil
+			} else if isTransientNetworkError(err) {
+				// Transient network error, treat it as if we didn't find anything
+				resp = nil
+			} else {
+				log.Printf("Error on InstanceStateRefresh: %s", err)
+				return nil, "", err
+			}
+		}
+
+		if resp == nil || len(resp.Reservations) == 0 || len(resp.Reservations[0].Instances) == 0 {
+			// Sometimes AWS just has consistency issues and doesn't see
+			// our instance yet. Return an empty state.
+			return nil, "", nil
+		}
+
+		i := &resp.Reservations[0].Instances[0]
+		return i, i.State.Name, nil
+	}
+}
+
+// SpotRequestStateRefreshFunc returns a StateRefreshFunc that is used to watch
+// a spot request for state changes.
+func SpotRequestStateRefreshFunc(conn *ec2.EC2, spotRequestId string) StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeSpotRequests([]string{spotRequestId}, ec2.NewFilter())
+		if err != nil {
+			if ec2err, ok := err.(*ec2.Error); ok && ec2err.Code == "InvalidSpotInstanceRequestID.NotFound" {
+				// Set this to nil as if we didn't find anything.
+				resp = nil
+			} else if isTransientNetworkError(err) {
+				// Transient network error, treat it as if we didn't find anything
+				resp = nil
+			} else {
+				log.Printf("Error on SpotRequestStateRefresh: %s", err)
+				return nil, "", err
+			}
+		}
+
+		if resp == nil || len(resp.SpotRequestResults) == 0 {
+			// Sometimes AWS has consistency issues and doesn't see the
+			// SpotRequest. Return an empty state.
+			return nil, "", nil
+		}
+
+		i := resp.SpotRequestResults[0]
+		return i, i.State, nil
+	}
+}
+
+// WaitForState watches an object and waits for it to achieve a certain
+// state.
+func WaitForState(conf *StateChangeConf) (i interface{}, err error) {
+	log.Printf("Waiting for state to become: %s", conf.Target)
+
+	sleepSeconds := 2
+	maxTicks := int(TimeoutSeconds()/sleepSeconds) + 1
+	notfoundTick := 0
+
+	for {
+		var currentState string
+		i, currentState, err = conf.Refresh()
+		if err != nil {
+			return
+		}
+
+		if i == nil {
+			// If we didn't find the resource, check if we have been
+			// not finding it for awhile, and if so, report an error.
+			notfoundTick += 1
+			if notfoundTick > maxTicks {
+				return nil, errors.New("couldn't find resource")
+			}
+		} else {
+			// Reset the counter for when a resource isn't found
+			notfoundTick = 0
+
+			if currentState == conf.Target {
+				return
+			}
+
+			if conf.StepState != nil {
+				if _, ok := conf.StepState.GetOk(multistep.StateCancelled); ok {
+					return nil, errors.New("interrupted")
+				}
+			}
+
+			found := false
+			for _, allowed := range conf.Pending {
+				if currentState == allowed {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				err := fmt.Errorf("unexpected state '%s', wanted target '%s'", currentState, conf.Target)
+				return nil, err
+			}
+		}
+
+		time.Sleep(time.Duration(sleepSeconds) * time.Second)
+	}
+
+	return
+}
+
+func isTransientNetworkError(err error) bool {
+	if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
+		return true
+	}
+
+	return false
+}
+
+// Returns 300 seconds (5 minutes) by default
+// Some AWS operations, like copying an AMI to a distant region, take a very long time
+// Allow user to override with AWS_TIMEOUT_SECONDS environment variable
+func TimeoutSeconds() (seconds int) {
+	seconds = 300
+
+	override := os.Getenv("AWS_TIMEOUT_SECONDS")
+	if override != "" {
+		n, err := strconv.Atoi(override)
+		if err != nil {
+			log.Printf("Invalid timeout seconds '%s', using default", override)
+		} else {
+			seconds = n
+		}
+	}
+
+	log.Printf("Allowing %ds to complete (change with AWS_TIMEOUT_SECONDS)", seconds)
+	return seconds
+}

--- a/builder/amazon-windows/common/step_run_source_instance.go
+++ b/builder/amazon-windows/common/step_run_source_instance.go
@@ -1,0 +1,287 @@
+package common
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/mitchellh/goamz/ec2"
+	"github.com/mitchellh/multistep"
+	awscommon "github.com/mitchellh/packer/builder/amazon/common"
+	"github.com/mitchellh/packer/packer"
+)
+
+type StepRunSourceInstance struct {
+	AssociatePublicIpAddress bool
+	AvailabilityZone         string
+	BlockDevices             awscommon.BlockDevices
+	Debug                    bool
+	ExpectedRootDevice       string
+	InstanceType             string
+	IamInstanceProfile       string
+	SourceAMI                string
+	SpotPrice                string
+	SpotPriceProduct         string
+	SubnetId                 string
+	Tags                     map[string]string
+	UserData                 string
+	UserDataFile             string
+
+	instance    *ec2.Instance
+	spotRequest *ec2.SpotRequestResult
+}
+
+func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepAction {
+	ec2conn := state.Get("ec2").(*ec2.EC2)
+	keyName := state.Get("keyPair").(string)
+	securityGroupIds := state.Get("securityGroupIds").([]string)
+	ui := state.Get("ui").(packer.Ui)
+
+	userData := s.UserData
+	if s.UserDataFile != "" {
+		contents, err := ioutil.ReadFile(s.UserDataFile)
+		if err != nil {
+			state.Put("error", fmt.Errorf("Problem reading user data file: %s", err))
+			return multistep.ActionHalt
+		}
+
+		userData = string(contents)
+	}
+
+	securityGroups := make([]ec2.SecurityGroup, len(securityGroupIds))
+	for n, securityGroupId := range securityGroupIds {
+		securityGroups[n] = ec2.SecurityGroup{Id: securityGroupId}
+	}
+
+	ui.Say("Launching a source AWS instance...")
+	imageResp, err := ec2conn.Images([]string{s.SourceAMI}, ec2.NewFilter())
+	if err != nil {
+		state.Put("error", fmt.Errorf("There was a problem with the source AMI: %s", err))
+		return multistep.ActionHalt
+	}
+
+	if len(imageResp.Images) != 1 {
+		state.Put("error", fmt.Errorf("The source AMI '%s' could not be found.", s.SourceAMI))
+		return multistep.ActionHalt
+	}
+
+	if s.ExpectedRootDevice != "" && imageResp.Images[0].RootDeviceType != s.ExpectedRootDevice {
+		state.Put("error", fmt.Errorf(
+			"The provided source AMI has an invalid root device type.\n"+
+				"Expected '%s', got '%s'.",
+			s.ExpectedRootDevice, imageResp.Images[0].RootDeviceType))
+		return multistep.ActionHalt
+	}
+
+	spotPrice := s.SpotPrice
+	if spotPrice == "auto" {
+		ui.Message(fmt.Sprintf(
+			"Finding spot price for %s %s...",
+			s.SpotPriceProduct, s.InstanceType))
+
+		// Detect the spot price
+		startTime := time.Now().Add(-1 * time.Hour)
+		resp, err := ec2conn.DescribeSpotPriceHistory(&ec2.DescribeSpotPriceHistory{
+			InstanceType:       []string{s.InstanceType},
+			ProductDescription: []string{s.SpotPriceProduct},
+			AvailabilityZone:   s.AvailabilityZone,
+			StartTime:          startTime,
+		})
+		if err != nil {
+			err := fmt.Errorf("Error finding spot price: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+		var price float64
+		for _, history := range resp.History {
+			log.Printf("[INFO] Candidate spot price: %s", history.SpotPrice)
+			current, err := strconv.ParseFloat(history.SpotPrice, 64)
+			if err != nil {
+				log.Printf("[ERR] Error parsing spot price: %s", err)
+				continue
+			}
+			if price == 0 || current < price {
+				price = current
+			}
+		}
+		if price == 0 {
+			err := fmt.Errorf("No candidate spot prices found!")
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+		spotPrice = strconv.FormatFloat(price, 'f', -1, 64)
+	}
+
+	var instanceId string
+
+	if spotPrice == "" {
+		runOpts := &ec2.RunInstances{
+			KeyName:                  keyName,
+			ImageId:                  s.SourceAMI,
+			InstanceType:             s.InstanceType,
+			UserData:                 []byte(userData),
+			MinCount:                 0,
+			MaxCount:                 0,
+			SecurityGroups:           securityGroups,
+			IamInstanceProfile:       s.IamInstanceProfile,
+			SubnetId:                 s.SubnetId,
+			AssociatePublicIpAddress: s.AssociatePublicIpAddress,
+			BlockDevices:             s.BlockDevices.BuildLaunchDevices(),
+			AvailZone:                s.AvailabilityZone,
+		}
+		runResp, err := ec2conn.RunInstances(runOpts)
+		if err != nil {
+			err := fmt.Errorf("Error launching source instance: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+		instanceId = runResp.Instances[0].InstanceId
+	} else {
+		ui.Message(fmt.Sprintf(
+			"Requesting spot instance '%s' for: %s",
+			s.InstanceType, spotPrice))
+
+		runOpts := &ec2.RequestSpotInstances{
+			SpotPrice:                spotPrice,
+			KeyName:                  keyName,
+			ImageId:                  s.SourceAMI,
+			InstanceType:             s.InstanceType,
+			UserData:                 []byte(userData),
+			SecurityGroups:           securityGroups,
+			IamInstanceProfile:       s.IamInstanceProfile,
+			SubnetId:                 s.SubnetId,
+			AssociatePublicIpAddress: s.AssociatePublicIpAddress,
+			BlockDevices:             s.BlockDevices.BuildLaunchDevices(),
+			AvailZone:                s.AvailabilityZone,
+		}
+		runSpotResp, err := ec2conn.RequestSpotInstances(runOpts)
+		if err != nil {
+			err := fmt.Errorf("Error launching source spot instance: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+		s.spotRequest = &runSpotResp.SpotRequestResults[0]
+
+		spotRequestId := s.spotRequest.SpotRequestId
+		ui.Message(fmt.Sprintf("Waiting for spot request (%s) to become active...", spotRequestId))
+		stateChange := awscommon.StateChangeConf{
+			Pending:   []string{"open"},
+			Target:    "active",
+			Refresh:   awscommon.SpotRequestStateRefreshFunc(ec2conn, spotRequestId),
+			StepState: state,
+		}
+		_, err = awscommon.WaitForState(&stateChange)
+		if err != nil {
+			err := fmt.Errorf("Error waiting for spot request (%s) to become ready: %s", spotRequestId, err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+		spotResp, err := ec2conn.DescribeSpotRequests([]string{spotRequestId}, nil)
+		if err != nil {
+			err := fmt.Errorf("Error finding spot request (%s): %s", spotRequestId, err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+		instanceId = spotResp.SpotRequestResults[0].InstanceId
+	}
+
+	ui.Message(fmt.Sprintf("Instance ID: %s", instanceId))
+
+	ui.Say(fmt.Sprintf("Waiting for instance (%v) to become ready...", instanceId))
+	stateChange := StateChangeConf{
+		Pending:   []string{"pending"},
+		Target:    "running",
+		Refresh:   InstanceStateRefreshFunc(ec2conn, instanceId),
+		StepState: state,
+	}
+	latestInstance, err := WaitForState(&stateChange)
+	if err != nil {
+		err := fmt.Errorf("Error waiting for instance (%s) to become ready: %s", s.instance.InstanceId, err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	s.instance = latestInstance.(*ec2.Instance)
+
+	ec2Tags := make([]ec2.Tag, 1, len(s.Tags)+1)
+	ec2Tags[0] = ec2.Tag{"Name", "Packer Builder"}
+	for k, v := range s.Tags {
+		ec2Tags = append(ec2Tags, ec2.Tag{k, v})
+	}
+
+	_, err = ec2conn.CreateTags([]string{s.instance.InstanceId}, ec2Tags)
+	if err != nil {
+		ui.Message(
+			fmt.Sprintf("Failed to tag a Name on the builder instance: %s", err))
+	}
+
+	if s.Debug {
+		if s.instance.DNSName != "" {
+			ui.Message(fmt.Sprintf("Public DNS: %s", s.instance.DNSName))
+		}
+
+		if s.instance.PublicIpAddress != "" {
+			ui.Message(fmt.Sprintf("Public IP: %s", s.instance.PublicIpAddress))
+		}
+
+		if s.instance.PrivateIpAddress != "" {
+			ui.Message(fmt.Sprintf("Private IP: %s", s.instance.PrivateIpAddress))
+		}
+	}
+
+	state.Put("instance", s.instance)
+
+	return multistep.ActionContinue
+}
+
+func (s *StepRunSourceInstance) Cleanup(state multistep.StateBag) {
+
+	ec2conn := state.Get("ec2").(*ec2.EC2)
+	ui := state.Get("ui").(packer.Ui)
+
+	// Cancel the spot request if it exists
+	if s.spotRequest != nil {
+		ui.Say("Cancelling the spot request...")
+		if _, err := ec2conn.CancelSpotRequests([]string{s.spotRequest.SpotRequestId}); err != nil {
+			ui.Error(fmt.Sprintf("Error cancelling the spot request, may still be around: %s", err))
+			return
+		}
+		stateChange := awscommon.StateChangeConf{
+			Pending: []string{"active", "open"},
+			Refresh: awscommon.SpotRequestStateRefreshFunc(ec2conn, s.spotRequest.SpotRequestId),
+			Target:  "cancelled",
+		}
+
+		awscommon.WaitForState(&stateChange)
+
+	}
+
+	// Terminate the source instance if it exists
+	if s.instance != nil {
+
+		ui.Say("Terminating the source AWS instance...")
+		if _, err := ec2conn.TerminateInstances([]string{s.instance.InstanceId}); err != nil {
+			ui.Error(fmt.Sprintf("Error terminating instance, may still be around: %s", err))
+			return
+		}
+		stateChange := awscommon.StateChangeConf{
+			Pending: []string{"pending", "running", "shutting-down", "stopped", "stopping"},
+			Refresh: awscommon.InstanceStateRefreshFunc(ec2conn, s.instance),
+			Target:  "terminated",
+		}
+
+		awscommon.WaitForState(&stateChange)
+	}
+}

--- a/builder/amazon-windows/common/step_run_source_instance.go
+++ b/builder/amazon-windows/common/step_run_source_instance.go
@@ -207,7 +207,7 @@ func (s *StepRunSourceInstance) Run(state multistep.StateBag) multistep.StepActi
 	}
 	latestInstance, err := WaitForState(&stateChange)
 	if err != nil {
-		err := fmt.Errorf("Error waiting for instance (%s) to become ready: %s", s.instance.InstanceId, err)
+		err := fmt.Errorf("Error waiting for instance (%s) to become ready: %s", instanceId, err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/amazon-windows/ebs/builder.go
+++ b/builder/amazon-windows/ebs/builder.go
@@ -98,7 +98,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			WinRMPort:        b.config.WinRMPort,
 			VpcId:            b.config.VpcId,
 		},
-		&awscommon.StepRunSourceInstance{
+		&winawscommon.StepRunSourceInstance{
 			Debug:                    b.config.PackerDebug,
 			ExpectedRootDevice:       "ebs",
 			SpotPrice:                b.config.SpotPrice,

--- a/builder/amazon-windows/instance/builder.go
+++ b/builder/amazon-windows/instance/builder.go
@@ -202,7 +202,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			WinRMPort:        b.config.WinRMPort,
 			VpcId:            b.config.VpcId,
 		},
-		&awscommon.StepRunSourceInstance{
+		&winawscommon.StepRunSourceInstance{
 			Debug:                    b.config.PackerDebug,
 			SpotPrice:                b.config.SpotPrice,
 			SpotPriceProduct:         b.config.SpotPriceAutoProduct,


### PR DESCRIPTION
Fixes issue with AWS API eventual consistency, resulting in `The instance ID does not exist (InvalidInstanceID.NotFound)` type errors.

Have tested 10 times and have not reproduced the problem - this does not necessarily indicate that the issue has completely disappeared, but either way this implementation is more reliable than the previous.

Have also tested user cancellation during this process.