### PR TITLE
Updated ExecutionTimeLimit to 24 hours to match commit @dd01a98a03273…

### DIFF
--- a/provisioner/powershell/elevated.go
+++ b/provisioner/powershell/elevated.go
@@ -47,7 +47,7 @@ $t.XmlText = @'
     <Hidden>false</Hidden>
     <RunOnlyIfIdle>false</RunOnlyIfIdle>
     <WakeToRun>false</WakeToRun>
-    <ExecutionTimeLimit>PT2H</ExecutionTimeLimit>
+    <ExecutionTimeLimit>PT24H</ExecutionTimeLimit>
     <Priority>4</Priority>
   </Settings>
   <Actions Context="Author">


### PR DESCRIPTION
Fixes #44 - Updated ExecutionTimeLimit on task definition used by the Powershell Provisioner for elevated permissions.