### PR TITLE
Add 'install' Makefile target for installing to ~/.packer.d/plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,8 @@ testrace:
 updatedeps:
 	go get -d -v -p 2 ./...
 
-.PHONY: bin default dev test updatedeps
+install:
+	@[ -d "${HOME}/.packer.d/plugins" ] || mkdir -p "${HOME}/.packer.d/plugins"
+	@cp $(wildcard bin/*) "${HOME}/.packer.d/plugins"
+
+.PHONY: bin default dev install test testrace updatedeps


### PR DESCRIPTION
Not sure if this is helpful, but since finally getting dev builds sorted out on my machine I thought it'd be handy to be able to update the binaries in `~/.packer.d/plugins`. Not at all a Makefile expert, so there might well be a saner way to do this..